### PR TITLE
Add movie and box-set providers, fix episode titles and fix image provider

### DIFF
--- a/Shokofin/Configuration/PluginConfiguration.cs
+++ b/Shokofin/Configuration/PluginConfiguration.cs
@@ -38,17 +38,17 @@ namespace Shokofin.Configuration
 
         public bool SynopsisCleanMultiEmptyLines { get; set; }
 
-        public enum DisplayTitleType {
+        public enum DisplayLanguageType {
             Default,
-            Localized,
+            MetadataPreferred,
             Origin,
         }
 
         public bool TitleUseAlternate { get; set; }
 
-        public DisplayTitleType TitleMainType { get; set; }
+        public DisplayLanguageType TitleMainType { get; set; }
 
-        public DisplayTitleType TitleAlternateType { get; set; }
+        public DisplayLanguageType TitleAlternateType { get; set; }
 
         public PluginConfiguration()
         {
@@ -70,8 +70,8 @@ namespace Shokofin.Configuration
             SynopsisRemoveSummary = true;
             SynopsisCleanMultiEmptyLines = true;
             TitleUseAlternate = true;
-            TitleMainType = DisplayTitleType.Default;
-            TitleAlternateType = DisplayTitleType.Origin;
+            TitleMainType = DisplayLanguageType.Default;
+            TitleAlternateType = DisplayLanguageType.Origin;
         }
     }
 }

--- a/Shokofin/Configuration/configPage.html
+++ b/Shokofin/Configuration/configPage.html
@@ -31,7 +31,7 @@
                     <label class="selectLabel" for="TitleMainType">Main Title Language</label>
                     <select is="emby-select" id="TitleMainType" name="TitleMainType" class="emby-select-withcolor emby-select">
                         <option value="Default">Default</option>
-                        <option value="Localized">Use preferred metadata language</option>
+                        <option value="MetadataPreferred">Preferred metadata language</option>
                         <option value="Origin">Language in country of origin</option>
                     </select>
                     <div class="fieldDescription">Titles will fallback to Default if not found for the target language.</div>
@@ -40,7 +40,7 @@
                     <label class="selectLabel" for="TitleAlternateType">Alternate Title Language</label>
                     <select is="emby-select" id="TitleAlternateType" name="TitleAlternateType" class="emby-select-withcolor emby-select">
                         <option value="Default">Default</option>
-                        <option value="Localized">Use preferred metadata language</option>
+                        <option value="MetadataPreferred">Preferred metadata language</option>
                         <option value="Origin">Language in country of origin</option>
                     </select>
                     <div class="fieldDescription">Titles will fallback to Default if not found for the target language.</div>

--- a/Shokofin/Providers/BoxSetProvider.cs
+++ b/Shokofin/Providers/BoxSetProvider.cs
@@ -62,7 +62,7 @@ namespace Shokofin.Providers
                     _logger.LogInformation("Shoko Scanner... series did not contain multiple movies! Skipping.");
                     return result;
                 }
-                var tags = await ShokoAPI.GetSeriesTags(seriesId, GetFlagFilter());
+                var tags = await ShokoAPI.GetSeriesTags(seriesId, Helper.GetTagFilter());
 
                 var ( displayTitle, alternateTitle ) = Helper.GetSeriesTitles(aniDbInfo.Titles, aniDbInfo.Title, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
                 result.Item = new BoxSet
@@ -115,20 +115,6 @@ namespace Shokofin.Providers
         public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
         {
             return _httpClientFactory.CreateClient().GetAsync(url, cancellationToken);
-        }
-
-        private int GetFlagFilter()
-        {
-            var config = Plugin.Instance.Configuration;
-            var filter = 0;
-
-            if (config.HideAniDbTags) filter = 1;
-            if (config.HideArtStyleTags) filter |= (filter << 1);
-            if (config.HideSourceTags) filter |= (filter << 2);
-            if (config.HideMiscTags) filter |= (filter << 3);
-            if (config.HidePlotTags) filter |= (filter << 4);
-
-            return filter;
         }
     }
 }

--- a/Shokofin/Providers/BoxSetProvider.cs
+++ b/Shokofin/Providers/BoxSetProvider.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
+using Shokofin.API;
+
+namespace Shokofin.Providers
+{
+    public class BoxSetProvider : IHasOrder, IRemoteMetadataProvider<BoxSet, BoxSetInfo>
+    {
+        public string Name => "Shoko";
+        public int Order => 1;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<BoxSetProvider> _logger;
+
+        public BoxSetProvider(IHttpClientFactory httpClientFactory, ILogger<BoxSetProvider> logger)
+        {
+            _logger = logger;
+            _httpClientFactory = httpClientFactory;
+        }
+
+        public async Task<MetadataResult<BoxSet>> GetMetadata(BoxSetInfo info, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = new MetadataResult<BoxSet>();
+
+                var dirname = Path.DirectorySeparatorChar + info.Path.Split(Path.DirectorySeparatorChar).Last();
+
+                _logger.LogInformation($"Shoko Scanner... Getting series ID ({dirname})");
+
+                var apiResponse = await ShokoAPI.GetSeriesPathEndsWith(dirname);
+                var seriesIDs = apiResponse.FirstOrDefault()?.IDs;
+                var seriesId = seriesIDs?.ID.ToString();
+
+                if (string.IsNullOrEmpty(seriesId))
+                {
+                    _logger.LogInformation("Shoko Scanner... BoxSet not found!");
+                    return result;
+                }
+                _logger.LogInformation($"Shoko Scanner... Getting series metadata ({dirname} - {seriesId})");
+
+                var aniDbInfo = await ShokoAPI.GetSeriesAniDb(seriesId);
+                if (aniDbInfo.SeriesType != "0" /* Movie */)
+                {
+                    _logger.LogInformation("Shoko Scanner... series was not a movie! Skipping.");
+                    return result;
+                }
+
+                var seriesInfo = await ShokoAPI.GetSeries(seriesId);
+                if (seriesInfo.Sizes.Total.Episodes <= 1)
+                {
+                    _logger.LogInformation("Shoko Scanner... series did not contain multiple movies! Skipping.");
+                    return result;
+                }
+                var tags = await ShokoAPI.GetSeriesTags(seriesId, GetFlagFilter());
+
+                var ( displayTitle, alternateTitle ) = Helper.GetSeriesTitles(aniDbInfo.Titles, aniDbInfo.Title, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
+                result.Item = new BoxSet
+                {
+                    Name = displayTitle,
+                    OriginalTitle = alternateTitle,
+                    Overview = Helper.SummarySanitizer(aniDbInfo.Description),
+                    PremiereDate = aniDbInfo.AirDate,
+                    EndDate = aniDbInfo.EndDate,
+                    ProductionYear = aniDbInfo.AirDate?.Year,
+                    Tags = tags?.Select(tag => tag.Name).ToArray() ?? new string[0],
+                    CommunityRating = (float)((aniDbInfo.Rating.Value * 10) / aniDbInfo.Rating.MaxValue)
+                };
+                result.Item.SetProviderId("Shoko Series", seriesId);
+                result.HasMetadata = true;
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e.StackTrace);
+                return new MetadataResult<BoxSet>();
+            }
+        }
+
+        public async Task<IEnumerable<RemoteSearchResult>> GetSearchResults(BoxSetInfo searchInfo, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation($"Shoko Scanner... Searching BoxSet ({searchInfo.Name})");
+            var searchResults = await ShokoAPI.SeriesSearch(searchInfo.Name);
+            var results = new List<RemoteSearchResult>();
+
+            foreach (var series in searchResults)
+            {
+                var imageUrl = Helper.GetImageUrl(series.Images.Posters.FirstOrDefault());
+                _logger.LogInformation(imageUrl);
+                var parsedBoxSet = new RemoteSearchResult
+                {
+                    Name = series.Name,
+                    SearchProviderName = Name,
+                    ImageUrl = imageUrl
+                };
+                parsedBoxSet.SetProviderId("Shoko", series.IDs.ID.ToString());
+                results.Add(parsedBoxSet);
+            }
+
+            return results;
+        }
+
+
+        public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
+        {
+            return _httpClientFactory.CreateClient().GetAsync(url, cancellationToken);
+        }
+
+        private int GetFlagFilter()
+        {
+            var config = Plugin.Instance.Configuration;
+            var filter = 0;
+
+            if (config.HideAniDbTags) filter = 1;
+            if (config.HideArtStyleTags) filter |= (filter << 1);
+            if (config.HideSourceTags) filter |= (filter << 2);
+            if (config.HideMiscTags) filter |= (filter << 3);
+            if (config.HidePlotTags) filter |= (filter << 4);
+
+            return filter;
+        }
+    }
+}

--- a/Shokofin/Providers/EpisodeProvider.cs
+++ b/Shokofin/Providers/EpisodeProvider.cs
@@ -57,8 +57,9 @@ namespace Shokofin.Providers
                 _logger.LogInformation($"Shoko Scanner... Getting episode metadata ({filename} - {episodeId})");
 
                 var seriesInfo = await ShokoAPI.GetSeriesAniDb(seriesId);
+                var episode = await ShokoAPI.GetEpisode(episodeId);
                 var episodeInfo = await ShokoAPI.GetEpisodeAniDb(episodeId);
-                var ( displayTitle, alternateTitle ) = Helper.GetEpisodeTitles(seriesInfo.Titles, episodeInfo.Titles, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
+                var ( displayTitle, alternateTitle ) = Helper.GetEpisodeTitles(seriesInfo.Titles, episodeInfo.Titles, episode.Name, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
 
                 result.Item = new Episode
                 {

--- a/Shokofin/Providers/Helper.cs
+++ b/Shokofin/Providers/Helper.cs
@@ -52,14 +52,20 @@ namespace Shokofin.Providers
             {
                 case EpisodeType.Episode:
                     return null;
+                case EpisodeType.Credits:
+                    return ExtraType.ThemeVideo;
                 case EpisodeType.Trailer:
                     return ExtraType.Trailer;
                 case EpisodeType.Special: {
-                    var enTitle = Helper.GetTitleByLanguages(episode.Titles, "en");
-                    if (enTitle != null && (enTitle.Contains("intro") || enTitle.Contains("outro"))) {
-                        return ExtraType.DeletedScene;
-                    }
-                    return ExtraType.Scene;
+                    var title = Helper.GetTitleByLanguages(episode.Titles, "en") ?? "";
+                    // Interview
+                    if (title.Contains("interview", System.StringComparison.OrdinalIgnoreCase))
+                        return ExtraType.Interview;
+                    // Cinema intro/outro
+                    if (title.StartsWith("cinema ", System.StringComparison.OrdinalIgnoreCase) &&
+                    (title.Contains("intro", System.StringComparison.OrdinalIgnoreCase) || title.Contains("outro", System.StringComparison.OrdinalIgnoreCase)))
+                        return ExtraType.Clip;
+                    return null;
                 }
                 default:
                     return null;

--- a/Shokofin/Providers/Helper.cs
+++ b/Shokofin/Providers/Helper.cs
@@ -3,10 +3,8 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Shokofin.API.Models;
-using Title = Shokofin.API.Models.Title;
 using DisplayLanguageType = Shokofin.Configuration.PluginConfiguration.DisplayLanguageType;
 using EpisodeType = Shokofin.API.Models.Episode.EpisodeType;
-using Models = Shokofin.API.Models;
 using MediaBrowser.Model.Entities;
 
 namespace Shokofin.Providers
@@ -18,18 +16,13 @@ namespace Shokofin.Providers
             return image != null ? $"http://{Plugin.Instance.Configuration.Host}:{Plugin.Instance.Configuration.Port}/api/v3/Image/{image.Source}/{image.Type}/{image.ID}" : null;
         }
 
-        public static (int, int) GetNumbers(Models.Series series, Models.Episode.AniDB episode)
-        {
-            return (GetIndexNumber(series, episode), GetMaxNumber(series));
-        }
-
         /// <summary>
         /// 
         /// </summary>
         /// <param name="series"></param>
         /// <param name="episode"></param>
         /// <returns></returns>
-        public static int GetIndexNumber(Models.Series series, Models.Episode.AniDB episode)
+        public static int GetIndexNumber(Series series, Episode.AniDB episode)
         {
             int offset = 0;
             switch (episode.Type)
@@ -55,13 +48,7 @@ namespace Shokofin.Providers
             return offset + episode.EpisodeNumber;
         }
 
-        public static int GetMaxNumber(Models.Series series)
-        {
-            var dict = series.Sizes.Total;
-            return dict.Episodes + dict?.Specials ?? 0 + dict?.Credits ?? 0 + dict?.Others ?? 0 + dict?.Parodies ?? 0 + dict?.Trailers ?? 0;
-        }
-
-        public static ExtraType? GetExtraType(Models.Episode.AniDB episode)
+        public static ExtraType? GetExtraType(Episode.AniDB episode)
         {
             switch (episode.Type)
             {

--- a/Shokofin/Providers/Helper.cs
+++ b/Shokofin/Providers/Helper.cs
@@ -81,7 +81,7 @@ namespace Shokofin.Providers
             }
         }
 
-        public static int GetFlagFilter()
+        public static int GetTagFilter()
         {
             var config = Plugin.Instance.Configuration;
             var filter = 0;

--- a/Shokofin/Providers/Helper.cs
+++ b/Shokofin/Providers/Helper.cs
@@ -15,21 +15,35 @@ namespace Shokofin.Providers
             return image != null ? $"http://{Plugin.Instance.Configuration.Host}:{Plugin.Instance.Configuration.Port}/api/v3/Image/{image.Source}/{image.Type}/{image.ID}" : null;
         }
 
+        public static int GetFlagFilter()
+        {
+            var config = Plugin.Instance.Configuration;
+            var filter = 0;
+
+            if (config.HideAniDbTags) filter = 1;
+            if (config.HideArtStyleTags) filter |= (filter << 1);
+            if (config.HideSourceTags) filter |= (filter << 2);
+            if (config.HideMiscTags) filter |= (filter << 3);
+            if (config.HidePlotTags) filter |= (filter << 4);
+
+            return filter;
+        }
+
         public static string SummarySanitizer(string summary) // Based on ShokoMetadata which is based on HAMA's
         {
             var config = Plugin.Instance.Configuration;
-            
+
             if (config.SynopsisCleanLinks)
                 summary = Regex.Replace(summary, @"https?:\/\/\w+.\w+(?:\/?\w+)? \[([^\]]+)\]", match => match.Groups[1].Value);
             
             if (config.SynopsisCleanMiscLines)
                 summary = Regex.Replace(summary, @"^(\*|--|~) .*", "", RegexOptions.Multiline);
-            
+
             if (config.SynopsisRemoveSummary)
                 summary = Regex.Replace(summary, @"\n(Source|Note|Summary):.*", "", RegexOptions.Singleline);
-            
+
             if (config.SynopsisCleanMultiEmptyLines)
-                summary = Regex.Replace(summary, @"\n\n+", "", RegexOptions.Singleline); 
+                summary = Regex.Replace(summary, @"\n\n+", "", RegexOptions.Singleline);
 
             return summary;
         }

--- a/Shokofin/Providers/Helper.cs
+++ b/Shokofin/Providers/Helper.cs
@@ -17,12 +17,10 @@ namespace Shokofin.Providers
         }
 
         /// <summary>
-        /// 
+        /// Get absolute index number for an episode in a series.
         /// </summary>
-        /// <param name="series"></param>
-        /// <param name="episode"></param>
-        /// <returns></returns>
-        public static int GetIndexNumber(Series series, Episode.AniDB episode)
+        /// <returns>Absolute index.</returns>
+        public static int GetAbsoluteIndexNumber(Series series, Episode.AniDB episode)
         {
             int offset = 0;
             switch (episode.Type)

--- a/Shokofin/Providers/MovieProvider.cs
+++ b/Shokofin/Providers/MovieProvider.cs
@@ -73,7 +73,7 @@ namespace Shokofin.Providers
 
                 var tags = await ShokoAPI.GetSeriesTags(seriesId, Helper.GetTagFilter());
                 var ( displayTitle, alternateTitle ) = Helper.GetMovieTitles(seriesAniDB.Titles, episodeAniDB.Titles, series.Name, episode.Name, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
-                float comRat = isMultiEntry ? (float)((episodeAniDB.Rating.Value * 10) / episodeAniDB.Rating.MaxValue) : (float)((seriesAniDB.Rating.Value * 10) / seriesAniDB.Rating.MaxValue);
+                float rating = isMultiEntry ? (float)((episodeAniDB.Rating.Value * 10) / episodeAniDB.Rating.MaxValue) : (float)((seriesAniDB.Rating.Value * 10) / seriesAniDB.Rating.MaxValue);
                 ExtraType? extraType = Helper.GetExtraType(episodeAniDB);
 
                 result.Item = new Movie
@@ -81,13 +81,13 @@ namespace Shokofin.Providers
                     IndexNumber = Helper.GetIndexNumber(series, episodeAniDB),
                     Name = displayTitle,
                     OriginalTitle = alternateTitle,
-                    PremiereDate = isMultiEntry ? episodeAniDB.AirDate : seriesAniDB.AirDate,
+                    PremiereDate = episodeAniDB.AirDate,
                     // Use the file description if collection contains more than one movie, otherwise use the collection description.
-                    Overview = Helper.SummarySanitizer((isMultiEntry ? episodeAniDB.Description : seriesAniDB.Description) ?? ""),
-                    ProductionYear = isMultiEntry ? episodeAniDB.AirDate?.Year : seriesAniDB.AirDate?.Year,
+                    Overview = Helper.SummarySanitizer((isMultiEntry ? episodeAniDB.Description ?? seriesAniDB.Description : seriesAniDB.Description) ?? ""),
+                    ProductionYear = episodeAniDB.AirDate?.Year,
                     ExtraType = extraType,                    
                     Tags = tags?.Select(tag => tag.Name).ToArray() ?? new string[0],
-                    CommunityRating = comRat,
+                    CommunityRating = rating,
                 };
                 result.Item.SetProviderId("Shoko File", fileId);
                 result.Item.SetProviderId("Shoko Series", seriesId);

--- a/Shokofin/Providers/MovieProvider.cs
+++ b/Shokofin/Providers/MovieProvider.cs
@@ -71,7 +71,7 @@ namespace Shokofin.Providers
                     return result;
                 }
 
-                var tags = await ShokoAPI.GetSeriesTags(seriesId, Helper.GetFlagFilter());
+                var tags = await ShokoAPI.GetSeriesTags(seriesId, Helper.GetTagFilter());
                 var ( displayTitle, alternateTitle ) = Helper.GetMovieTitles(seriesAniDB.Titles, episodeAniDB.Titles, series.Name, episode.Name, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
                 float comRat = isMultiEntry ? (float)((episodeAniDB.Rating.Value * 10) / episodeAniDB.Rating.MaxValue) : (float)((seriesAniDB.Rating.Value * 10) / seriesAniDB.Rating.MaxValue);
                 ExtraType? extraType = Helper.GetExtraType(episodeAniDB);

--- a/Shokofin/Providers/MovieProvider.cs
+++ b/Shokofin/Providers/MovieProvider.cs
@@ -78,7 +78,7 @@ namespace Shokofin.Providers
 
                 result.Item = new Movie
                 {
-                    IndexNumber = Helper.GetIndexNumber(series, episodeAniDB),
+                    IndexNumber = Helper.GetAbsoluteIndexNumber(series, episodeAniDB),
                     Name = displayTitle,
                     OriginalTitle = alternateTitle,
                     PremiereDate = episodeAniDB.AirDate,

--- a/Shokofin/Providers/MovieProvider.cs
+++ b/Shokofin/Providers/MovieProvider.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
+using Shokofin.API;
+using EpisodeType = Shokofin.API.Models.Episode.EpisodeType;
+
+namespace Shokofin.Providers
+{
+    public class MovieProvider : IRemoteMetadataProvider<Movie, MovieInfo>
+    {
+        public string Name => "Shoko";
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<MovieProvider> _logger;
+
+        public MovieProvider(IHttpClientFactory httpClientFactory, ILogger<MovieProvider> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+
+        public async Task<MetadataResult<Movie>> GetMetadata(MovieInfo info, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = new MetadataResult<Movie>();
+
+                // TO-DO Check if it can be written in a better way. Parent directory + File Name
+                var filename = Path.Join(
+                        Path.GetDirectoryName(info.Path)?.Split(Path.DirectorySeparatorChar).LastOrDefault(),
+                        Path.GetFileName(info.Path));
+
+                _logger.LogInformation($"Shoko Scanner... Getting movie ID ({filename})");
+
+                var apiResponse = await ShokoAPI.GetFilePathEndsWith(filename);
+                var allIds = apiResponse.FirstOrDefault()?.SeriesIDs.FirstOrDefault();
+                var episodeIds = allIds?.EpisodeIDs?.FirstOrDefault();
+                string seriesId = allIds?.SeriesID.ID.ToString();
+                string episodeId = episodeIds?.ID.ToString();
+
+                if (string.IsNullOrEmpty(episodeId) || string.IsNullOrEmpty(seriesId))
+                {
+                    _logger.LogInformation($"Shoko Scanner... File not found! ({filename})");
+                    return result;
+                }
+
+                _logger.LogInformation($"Shoko Scanner... Getting movie metadata ({filename} - {episodeId})");
+
+                var seriesAniDB = await ShokoAPI.GetSeriesAniDb(seriesId);
+                var series = await ShokoAPI.GetSeries(seriesId);
+                var episodeAniDB = await ShokoAPI.GetEpisodeAniDb(episodeId);
+                bool isMultiEntry = series.Sizes.Total.Episodes > 1;
+                int tvdbId = (isMultiEntry ? episodeIds.TvDB?.FirstOrDefault() : allIds?.SeriesID.TvDB?.FirstOrDefault()) ?? 0;
+
+                if (seriesAniDB?.SeriesType != "0")
+                {
+                    _logger.LogInformation($"Shoko Scanner... File found, but not a movie! Skipping.");
+                    return result;
+                }
+
+                var ( displayTitle, alternateTitle ) = Helper.GetFullTitles(seriesAniDB.Titles, episodeAniDB.Titles, seriesAniDB.Title, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
+                var tags = await ShokoAPI.GetSeriesTags(seriesId, Helper.GetFlagFilter());
+                // Use the file description if collection contains more than one movie, otherwise use the collection description.
+                string description = (isMultiEntry ? episodeAniDB.Description : seriesAniDB.Description) ?? "";
+                float comRat = isMultiEntry ? (float)((episodeAniDB.Rating.Value * 10) / episodeAniDB.Rating.MaxValue) : (float)((seriesAniDB.Rating.Value * 10) / seriesAniDB.Rating.MaxValue);
+                ExtraType? extraType = GetExtraType(episodeAniDB.Type);
+
+                result.Item = new Movie
+                {
+                    IndexNumber = episodeAniDB.EpisodeNumber,
+                    Name = displayTitle,
+                    OriginalTitle = alternateTitle,
+                    PremiereDate = isMultiEntry ? episodeAniDB.AirDate : seriesAniDB.AirDate,
+                    Overview = Helper.SummarySanitizer(description),
+                    ProductionYear = isMultiEntry ? episodeAniDB.AirDate?.Year : seriesAniDB.AirDate?.Year,
+                    ExtraType = extraType,
+                    Tags = tags?.Select(tag => tag.Name).ToArray() ?? new string[0],
+                    CommunityRating = comRat,
+                };
+                result.Item.SetProviderId("Shoko Series", seriesId);
+                result.Item.SetProviderId("Shoko Episode", episodeId);
+                result.Item.SetProviderId("AniDB", allIds?.SeriesID.AniDB.ToString());
+                if (tvdbId != 0) result.Item.SetProviderId("Tvdb", tvdbId.ToString());
+                result.HasMetadata = true;
+
+                result.ResetPeople();
+                var roles = await ShokoAPI.GetSeriesCast(seriesId);
+                foreach (var role in roles)
+                {
+                    result.AddPerson(new PersonInfo
+                    {
+                        Type = PersonType.Actor,
+                        Name = role.Staff.Name,
+                        Role = role.Character.Name,
+                        ImageUrl = Helper.GetImageUrl(role.Staff.Image)
+                    });
+                }
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e.Message);
+                _logger.LogError(e.InnerException?.StackTrace ?? e.StackTrace);
+                return new MetadataResult<Movie>();
+            }
+        }
+
+        private ExtraType? GetExtraType(EpisodeType type)
+        {
+            switch (type)
+            {
+                case EpisodeType.Episode:
+                    return null;
+                case EpisodeType.Trailer:
+                    return ExtraType.Trailer;
+                case EpisodeType.Special:
+                    return ExtraType.Scene;
+                default:
+                    return ExtraType.Unknown;
+            }
+        }
+
+        public Task<IEnumerable<RemoteSearchResult>> GetSearchResults(MovieInfo searchInfo, CancellationToken cancellationToken)
+        {
+            // Isn't called from anywhere. If it is called, I don't know from where.
+            throw new NotImplementedException();
+        }
+
+        public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
+        {
+            return _httpClientFactory.CreateClient().GetAsync(url, cancellationToken);
+        }
+    }
+}

--- a/Shokofin/Providers/SeriesProvider.cs
+++ b/Shokofin/Providers/SeriesProvider.cs
@@ -53,7 +53,7 @@ namespace Shokofin.Providers
                 var seriesInfo = await ShokoAPI.GetSeries(seriesId);
                 var aniDbSeriesInfo = await ShokoAPI.GetSeriesAniDb(seriesId);
 
-                var tags = await ShokoAPI.GetSeriesTags(seriesId, Helper.GetFlagFilter());
+                var tags = await ShokoAPI.GetSeriesTags(seriesId, Helper.GetTagFilter());
                 var ( displayTitle, alternateTitle ) = Helper.GetSeriesTitles(aniDbSeriesInfo.Titles, seriesInfo.Name, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
 
                 result.Item = new Series


### PR DESCRIPTION

## Changes

- Renamed `DisplayTitleType` to `DisplayLanguageType` and `DisplayLanguageType.Localized` to `DisplayLanguageType.MetadataPreferred`.

- Fixed episode titles. They now _only_ show the episode title, and not the combined title, as they should.

- When `DisplayLanguageType.Default` is used will the episode title be set from Shoko.

- Added movie and box-set providers with image support.

- Fixed the image provider for series/episodes that I broke when separating the episode/series ids.