### PR TITLE
Use operation system agnostic path separators

### DIFF
--- a/Shokofin/API/Models/File.cs
+++ b/Shokofin/API/Models/File.cs
@@ -80,7 +80,7 @@ public class File
         /// where the <see cref="File"/> lies, with a leading slash applied at
         /// the start.
         /// </summary>
-        public string Path => "/" + RelativePath;
+        public string Path => System.IO.Path.DirectorySeparatorChar + RelativePath;
 
         /// <summary>
         /// True if the server can access the the <see cref="Location.Path"/> at

--- a/Shokofin/API/Models/File.cs
+++ b/Shokofin/API/Models/File.cs
@@ -80,7 +80,19 @@ public class File
         /// where the <see cref="File"/> lies, with a leading slash applied at
         /// the start.
         /// </summary>
-        public string Path => System.IO.Path.DirectorySeparatorChar + RelativePath;
+        public string Path =>
+            __path != null ? (
+                __path
+             ) : (
+                __path = System.IO.Path.DirectorySeparatorChar + RelativePath
+                    .Replace('/', System.IO.Path.DirectorySeparatorChar)
+                    .Replace('\\', System.IO.Path.DirectorySeparatorChar)
+             );
+
+        /// <summary>
+        /// Cached path for later re-use.
+        /// </summary>
+        private string? __path { get; set; }
 
         /// <summary>
         /// True if the server can access the the <see cref="Location.Path"/> at

--- a/Shokofin/API/ShokoAPIManager.cs
+++ b/Shokofin/API/ShokoAPIManager.cs
@@ -269,7 +269,7 @@ public class ShokoAPIManager
         foreach (var file in await APIClient.GetFilesForSeries(seriesId)) {
             if (file.CrossReferences.Count == 1)
                 foreach (var fileLocation in file.Locations)
-                    pathSet.Add((Path.GetDirectoryName(fileLocation.Path) ?? "") + "/");
+                    pathSet.Add((Path.GetDirectoryName(fileLocation.Path) ?? "") + Path.DirectorySeparatorChar);
             var xref = file.CrossReferences.First(xref => xref.Series.Shoko.ToString() == seriesId);
             foreach (var episodeXRef in xref.Episodes)
                 episodeIds.Add(episodeXRef.Shoko.ToString());
@@ -317,7 +317,7 @@ public class ShokoAPIManager
         }
 
         // Find the correct series based on the path.
-        var selectedPath = (Path.GetDirectoryName(fileLocations.First().Path) ?? "") + "/";
+        var selectedPath = (Path.GetDirectoryName(fileLocations.First().Path) ?? "") + Path.DirectorySeparatorChar;
         foreach (var seriesXRef in file.CrossReferences) {
             var seriesId = seriesXRef.Series.Shoko.ToString();
 


### PR DESCRIPTION
Fixes issue with windows based devices being unable to pull file based metadata