### PR TITLE
Adds targeted error handling for invalid shoko user tokens

### DIFF
--- a/Shokofin/API/ShokoAPIClient.cs
+++ b/Shokofin/API/ShokoAPIClient.cs
@@ -92,7 +92,7 @@ public class ShokoAPIClient : IDisposable
                 requestMessage.Headers.Add("apikey", apiKey);
                 var response = await _httpClient.SendAsync(requestMessage);
                 if (response.StatusCode == HttpStatusCode.Unauthorized)
-                    throw new HttpRequestException("Invalid or expired API Token. Please reconnect the plugin to Shoko Server by resetting the connection in the plugin settings.", null, HttpStatusCode.Unauthorized);
+                    throw new HttpRequestException("Invalid or expired API Token. Please reconnect the plugin to Shoko Server by resetting the connection or deleting and re-adding the user in the plugin settings.", null, HttpStatusCode.Unauthorized);
                 Logger.LogTrace("API returned response with status code {StatusCode}", response.StatusCode);
                 return response;
             }
@@ -146,7 +146,7 @@ public class ShokoAPIClient : IDisposable
                 requestMessage.Headers.Add("apikey", apiKey);
                 var response = await _httpClient.SendAsync(requestMessage);
                 if (response.StatusCode == HttpStatusCode.Unauthorized)
-                    throw new HttpRequestException("Invalid or expired API Token. Please reconnect the plugin to Shoko Server by resetting the connection in the plugin settings.", null, HttpStatusCode.Unauthorized);
+                    throw new HttpRequestException("Invalid or expired API Token. Please reconnect the plugin to Shoko Server by resetting the connection or deleting and re-adding the user in the plugin settings.", null, HttpStatusCode.Unauthorized);
                 Logger.LogTrace("API returned response with status code {StatusCode}", response.StatusCode);
                 return response;
             }

--- a/Shokofin/Sync/UserDataSyncManager.cs
+++ b/Shokofin/Sync/UserDataSyncManager.cs
@@ -239,9 +239,9 @@ namespace Shokofin.Sync
                 }
             }
             catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.Unauthorized) {
-                TryGetUserConfiguration(e.UserId, out var userConfig);
-                if (userConfig is not null)
-                    Logger.LogError(ex, "Invalid or expired API token used. In the plugin settings, please reset the connection to Shoko Server in the user settings section (Jellyfin User={Username})", UserManager.GetUserById(userConfig.UserId).Username);
+                if (TryGetUserConfiguration(e.UserId, out var userConfig))
+                    Logger.LogError(ex, "I{Message} (Username={Username},Id={UserId})", ex.Message, UserManager.GetUserById(userConfig.UserId)?.Username, userConfig.UserId);
+                return;
             }
             catch (Exception ex) {
                 Logger.LogError(ex, "Threw unexpectedly; {ErrorMessage}", ex.Message);


### PR DESCRIPTION
I'm sure there are much better ways of doing this, but this should be functional for the time being.

In the `UserDataSyncManager` class, wherever the user data specific token is used for an API call, if there is an invalid token it should be caught as an error and logged, also including the jellyfin username of the user config with the offending invalid token.

Could avoid using the `UserManager` interface if we just dump the guid of the user instead, but I figured that it's a lot easier for most if they can just read a username in the logs instead!

This has been tested with valid & invalid tokens and "Works on my machine™".