### PR TITLE
Add sortable checkboxes for description source

### DIFF
--- a/Shokofin/Configuration/PluginConfiguration.cs
+++ b/Shokofin/Configuration/PluginConfiguration.cs
@@ -9,7 +9,6 @@ using DisplayLanguageType = Shokofin.Utils.Text.DisplayLanguageType;
 using CollectionCreationType = Shokofin.Utils.Ordering.CollectionCreationType;
 using OrderType = Shokofin.Utils.Ordering.OrderType;
 using SpecialOrderType = Shokofin.Utils.Ordering.SpecialOrderType;
-using System;
 
 namespace Shokofin.Configuration;
 

--- a/Shokofin/Configuration/PluginConfiguration.cs
+++ b/Shokofin/Configuration/PluginConfiguration.cs
@@ -98,7 +98,12 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// The description source. This will be replaced in the future.
     /// </summary>
-    public TextSourceType DescriptionSource { get; set; }
+    public TextSourceType[] DescriptionSource { get; set; }
+
+    /// <summary>
+    /// The prioritisation order of source providers for description sources.
+    /// </summary>
+    public TextSourceType[] DescriptionSourceOrder { get; set; }
 
     /// <summary>
     /// Clean up links within the AniDB description for entries.
@@ -286,7 +291,8 @@ public class PluginConfiguration : BasePluginConfiguration
         TitleMainType = DisplayLanguageType.Default;
         TitleAlternateType = DisplayLanguageType.Origin;
         TitleAllowAny = false;
-        DescriptionSource = TextSourceType.Default;
+        DescriptionSource = new[] { TextSourceType.AniDb };
+        DescriptionSourceOrder = new[] { TextSourceType.AniDb, TextSourceType.TvDb, TextSourceType.TMDB };
         VirtualFileSystem = true;
         VirtualFileSystemThreads = 10;
         UseGroupsForShows = false;

--- a/Shokofin/Configuration/PluginConfiguration.cs
+++ b/Shokofin/Configuration/PluginConfiguration.cs
@@ -9,6 +9,7 @@ using DisplayLanguageType = Shokofin.Utils.Text.DisplayLanguageType;
 using CollectionCreationType = Shokofin.Utils.Ordering.CollectionCreationType;
 using OrderType = Shokofin.Utils.Ordering.OrderType;
 using SpecialOrderType = Shokofin.Utils.Ordering.SpecialOrderType;
+using System;
 
 namespace Shokofin.Configuration;
 
@@ -96,9 +97,14 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool MarkSpecialsWhenGrouped { get; set; }
 
     /// <summary>
-    /// The description source. This will be replaced in the future.
+    /// This setting is now deprecated. Use `DescriptionSourceList` instead.
     /// </summary>
-    public TextSourceType[] DescriptionSource { get; set; }
+    public string? DescriptionSource { get; set; }
+
+    /// <summary>
+    /// The collection of providers for descriptions
+    /// </summary>
+    public TextSourceType[] DescriptionSourceList { get; set; }
 
     /// <summary>
     /// The prioritisation order of source providers for description sources.
@@ -291,7 +297,8 @@ public class PluginConfiguration : BasePluginConfiguration
         TitleMainType = DisplayLanguageType.Default;
         TitleAlternateType = DisplayLanguageType.Origin;
         TitleAllowAny = false;
-        DescriptionSource = new[] { TextSourceType.AniDb };
+        DescriptionSource = null;
+        DescriptionSourceList = new[] { TextSourceType.AniDb, TextSourceType.TvDb, TextSourceType.TMDB };
         DescriptionSourceOrder = new[] { TextSourceType.AniDb, TextSourceType.TvDb, TextSourceType.TMDB };
         VirtualFileSystem = true;
         VirtualFileSystemThreads = 10;

--- a/Shokofin/Configuration/PluginConfiguration.cs
+++ b/Shokofin/Configuration/PluginConfiguration.cs
@@ -96,12 +96,7 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool MarkSpecialsWhenGrouped { get; set; }
 
     /// <summary>
-    /// This setting is now deprecated. Use `DescriptionSourceList` instead.
-    /// </summary>
-    public string? DescriptionSource { get; set; }
-
-    /// <summary>
-    /// The collection of providers for descriptions
+    /// The collection of providers for descriptions. Replaces the former `DescriptionSource`.
     /// </summary>
     public TextSourceType[] DescriptionSourceList { get; set; }
 
@@ -296,7 +291,6 @@ public class PluginConfiguration : BasePluginConfiguration
         TitleMainType = DisplayLanguageType.Default;
         TitleAlternateType = DisplayLanguageType.Origin;
         TitleAllowAny = false;
-        DescriptionSource = null;
         DescriptionSourceList = new[] { TextSourceType.AniDb, TextSourceType.TvDb, TextSourceType.TMDB };
         DescriptionSourceOrder = new[] { TextSourceType.AniDb, TextSourceType.TvDb, TextSourceType.TMDB };
         VirtualFileSystem = true;

--- a/Shokofin/Configuration/configController.js
+++ b/Shokofin/Configuration/configController.js
@@ -759,7 +759,7 @@ export default function (page) {
             form.querySelector("#TitleAllowAny").checked = config.TitleAllowAny;
             form.querySelector("#TitleAddForMultipleEpisodes").checked = config.TitleAddForMultipleEpisodes != null ? config.TitleAddForMultipleEpisodes : true;
             form.querySelector("#MarkSpecialsWhenGrouped").checked = config.MarkSpecialsWhenGrouped;
-            await setDescriptionSourcesFromConfig(form);
+            await setDescriptionSourcesFromConfig(form, config);
             form.querySelector("#CleanupAniDBDescriptions").checked = config.SynopsisCleanMultiEmptyLines || config.SynopsisCleanLinks;
             form.querySelector("#MinimalAniDBDescriptions").checked = config.SynopsisRemoveSummary || config.SynopsisCleanMiscLines;
 
@@ -884,9 +884,7 @@ function setDescriptionSourcesIntoConfig(form, config) {
     );
 }
 
-async function setDescriptionSourcesFromConfig(form) {
-  const config = await ApiClient.getPluginConfiguration(PluginConfig.pluginId);
-
+async function setDescriptionSourcesFromConfig(form, config) {
   migrateDescriptionSource(config);
 
   const list = form.querySelector("#descriptionSourceList .checkboxList");

--- a/Shokofin/Configuration/configController.js
+++ b/Shokofin/Configuration/configController.js
@@ -903,4 +903,7 @@ async function setDescriptionSourcesFromConfig(form, config) {
       list.append(targetElement);
     }
   }
+  for (const option of list.querySelectorAll(".sortableOption")) {
+    adjustSortableListElement(option)
+  };
 }

--- a/Shokofin/Configuration/configController.js
+++ b/Shokofin/Configuration/configController.js
@@ -46,6 +46,55 @@ const Messages = {
 
     // Convert it back into an array.
     return Array.from(filteredSet).sort((a, b) => a - b);
+ }
+
+ function adjustSortableListElement(element) {
+  const btnSortable = element.querySelector(".btnSortable");
+  const inner = btnSortable.querySelector(".material-icons");
+
+  if (element.previousElementSibling) {
+    btnSortable.title = "Up";
+    btnSortable.classList.add("btnSortableMoveUp");
+    inner.classList.add("keyboard_arrow_up");
+
+    btnSortable.classList.remove("btnSortableMoveDown");
+    inner.classList.remove("keyboard_arrow_down");
+  } else {
+    btnSortable.title = "Down";
+    btnSortable.classList.add("btnSortableMoveDown");
+    inner.classList.add("keyboard_arrow_down");
+
+    btnSortable.classList.remove("btnSortableMoveUp");
+    inner.classList.remove("keyboard_arrow_up");
+  }
+}
+
+function onSortableContainerClick(element) {
+  const parentWithClass = (element, className) => {
+    return (element.parentElement.classList.contains(className)) ? element.parentElement : null;
+  }
+  const btnSortable = parentWithClass(element.target, "btnSortable");
+  if (btnSortable) {
+    const listItem = parentWithClass(btnSortable, "sortableOption");
+    const list = parentWithClass(listItem, "paperList");
+    if (btnSortable.classList.contains("btnSortableMoveDown")) {
+      const next = listItem.nextElementSibling;
+      if (next) {
+        listItem.parentElement.removeChild(listItem);
+        next.parentElement.insertBefore(listItem, next.nextSibling);
+      }
+    } else {
+      const prev = listItem.previousElementSibling;
+      if (prev) {
+        listItem.parentElement.removeChild(listItem);
+        prev.parentElement.insertBefore(listItem, prev);
+      }
+    }
+
+    for (const option of list.querySelectorAll(".sortableOption")) {
+      adjustSortableListElement(option)
+    };
+  }
 }
 
 async function loadUserConfig(form, userId, config) {
@@ -227,7 +276,7 @@ async function defaultSubmit(form) {
         config.TitleAllowAny = form.querySelector("#TitleAllowAny").checked;
         config.TitleAddForMultipleEpisodes = form.querySelector("#TitleAddForMultipleEpisodes").checked;
         config.MarkSpecialsWhenGrouped = form.querySelector("#MarkSpecialsWhenGrouped").checked;
-        config.DescriptionSource = form.querySelector("#DescriptionSource").value;
+        setDescriptionSourcesIntoConfig(form, config);
         config.SynopsisCleanLinks = form.querySelector("#CleanupAniDBDescriptions").checked;
         config.SynopsisCleanMultiEmptyLines = form.querySelector("#CleanupAniDBDescriptions").checked;
         config.SynopsisCleanMiscLines = form.querySelector("#MinimalAniDBDescriptions").checked;
@@ -417,7 +466,7 @@ async function syncSettings(form) {
     config.TitleAllowAny = form.querySelector("#TitleAllowAny").checked;
     config.TitleAddForMultipleEpisodes = form.querySelector("#TitleAddForMultipleEpisodes").checked;
     config.MarkSpecialsWhenGrouped = form.querySelector("#MarkSpecialsWhenGrouped").checked;
-    config.DescriptionSource = form.querySelector("#DescriptionSource").value;
+    setDescriptionSourcesIntoConfig(form, config);
     config.SynopsisCleanLinks = form.querySelector("#CleanupAniDBDescriptions").checked;
     config.SynopsisCleanMultiEmptyLines = form.querySelector("#CleanupAniDBDescriptions").checked;
     config.SynopsisCleanMiscLines = form.querySelector("#MinimalAniDBDescriptions").checked;
@@ -689,6 +738,8 @@ export default function (page) {
         }
     });
 
+    form.querySelector("#descriptionSource").addEventListener("click", onSortableContainerClick);
+
     page.addEventListener("viewshow", async function () {
         Dashboard.showLoadingMsg();
         try {
@@ -707,7 +758,7 @@ export default function (page) {
             form.querySelector("#TitleAllowAny").checked = config.TitleAllowAny;
             form.querySelector("#TitleAddForMultipleEpisodes").checked = config.TitleAddForMultipleEpisodes != null ? config.TitleAddForMultipleEpisodes : true;
             form.querySelector("#MarkSpecialsWhenGrouped").checked = config.MarkSpecialsWhenGrouped;
-            form.querySelector("#DescriptionSource").value = config.DescriptionSource;
+            await setDescriptionSourcesFromConfig(form);
             form.querySelector("#CleanupAniDBDescriptions").checked = config.SynopsisCleanMultiEmptyLines || config.SynopsisCleanLinks;
             form.querySelector("#MinimalAniDBDescriptions").checked = config.SynopsisRemoveSummary || config.SynopsisCleanMiscLines;
 
@@ -818,4 +869,64 @@ export default function (page) {
         }
         return false;
     });
+}
+
+function setDescriptionSourcesIntoConfig(form, config) {
+  config.DescriptionSource = Array.prototype.map.call(
+    Array.prototype.filter.call(
+      form.querySelectorAll("#descriptionSource .chkDescriptionSource"),
+      (el) => el.checked
+    ),
+    (el) => el.dataset.descriptionsource
+  );
+
+  config.DescriptionSourceOrder = Array.prototype.map.call(
+    form.querySelectorAll("#descriptionSource .chkDescriptionSource"),
+    (el) => el.dataset.descriptionsource
+  );
+}
+
+async function setDescriptionSourcesFromConfig(form) {
+  const config = await ApiClient.getPluginConfiguration(PluginConfig.pluginId);
+
+  // #region Defaults
+  config.DescriptionSourceOrder ??= ["AniDB", "TMDB", "TVDB"]
+  if (typeof config.DescriptionSource === "string") {
+    // This should only trigger when migrating the string setting to an array setting
+    let checked = config.DescriptionSourceOrder;
+    let order = config.DescriptionSourceOrder;
+    switch (config.DescriptionSource) {
+      case "OnlyAniDb":
+        checked = ["AniDB"];
+        break;
+      case "OnlyOther":
+        checked = ["TMDB", "TVDB"];
+        order = ["TMDB", "TVDB", "AniDB"]
+        break;
+      case "PreferOther":
+        order = ["TMDB", "TVDB", "AniDB"];
+        break;
+    }
+    config.DescriptionSource = checked;
+    config.DescriptionSourceOrder = order;
+  }
+  // #endregion Defaults
+
+  const list = form.querySelector("#descriptionSource .checkboxList");
+  const listItems = list.querySelectorAll('.listItem');
+
+  for (const item of listItems) {
+    const source = item.dataset.descriptionsource;
+    if (config.DescriptionSource.includes(source)) {
+      item.querySelector(".chkDescriptionSource").checked = true;
+    }
+    if (config.DescriptionSourceOrder.includes(source)) {
+      list.removeChild(item); // This is safe to be removed as we can re-add it in the next loop
+    }
+  }
+
+  for (const source of config.DescriptionSourceOrder) {
+    const targetElement = Array.prototype.find.call(listItems, (el) => el.dataset.descriptionsource === source);
+    list.append(targetElement);
+  }
 }

--- a/Shokofin/Configuration/configController.js
+++ b/Shokofin/Configuration/configController.js
@@ -69,11 +69,12 @@ const Messages = {
   }
 }
 
-function onSortableContainerClick(element) {
+/** @param {PointerEvent} event */
+function onSortableContainerClick(event) {
   const parentWithClass = (element, className) => {
     return (element.parentElement.classList.contains(className)) ? element.parentElement : null;
   }
-  const btnSortable = parentWithClass(element.target, "btnSortable");
+  const btnSortable = parentWithClass(event.target, "btnSortable");
   if (btnSortable) {
     const listItem = parentWithClass(btnSortable, "sortableOption");
     const list = parentWithClass(listItem, "paperList");
@@ -872,18 +873,14 @@ export default function (page) {
 }
 
 function setDescriptionSourcesIntoConfig(form, config) {
-  config.DescriptionSource = Array.prototype.map.call(
-    Array.prototype.filter.call(
-      form.querySelectorAll("#descriptionSource .chkDescriptionSource"),
-      (el) => el.checked
-    ),
-    (el) => el.dataset.descriptionsource
-  );
+    const descriptionElements = form.querySelectorAll(`#descriptionSource .chkDescriptionSource`);
+    config.DescriptionSource = Array.prototype.filter.call(descriptionElements,
+        (el) => el.checked)
+        .map((el) => el.dataset.descriptionsource);
 
-  config.DescriptionSourceOrder = Array.prototype.map.call(
-    form.querySelectorAll("#descriptionSource .chkDescriptionSource"),
-    (el) => el.dataset.descriptionsource
-  );
+    config.DescriptionSourceOrder = Array.prototype.map.call(descriptionElements,
+        (el) => el.dataset.descriptionsource
+    );
 }
 
 async function setDescriptionSourcesFromConfig(form) {

--- a/Shokofin/Configuration/configController.js
+++ b/Shokofin/Configuration/configController.js
@@ -874,7 +874,6 @@ export default function (page) {
 
 function setDescriptionSourcesIntoConfig(form, config) {
     const descriptionElements = form.querySelectorAll(`#descriptionSourceList .chkDescriptionSource`);
-    config.DescriptionSource = "";
     config.DescriptionSourceList = Array.prototype.filter.call(descriptionElements,
         (el) => el.checked)
         .map((el) => el.dataset.descriptionsource);
@@ -885,8 +884,6 @@ function setDescriptionSourcesIntoConfig(form, config) {
 }
 
 async function setDescriptionSourcesFromConfig(form, config) {
-  migrateDescriptionSource(config);
-
   const list = form.querySelector("#descriptionSourceList .checkboxList");
   const listItems = list.querySelectorAll('.listItem');
 
@@ -906,27 +903,4 @@ async function setDescriptionSourcesFromConfig(form, config) {
       list.append(targetElement);
     }
   }
-}
-
-function migrateDescriptionSource(config) {
-    if (config.DescriptionSource !== null) {
-        let checked = config.DescriptionSourceList;
-        let order = config.DescriptionSourceOrder;
-        switch (config.DescriptionSource) {
-            case "OnlyAniDb":
-                checked = ["AniDb"];
-                break;
-            case "OnlyOther":
-                checked = ["TMDB", "TvDb"];
-                order = ["TMDB", "TvDb", "AniDb"]
-                break;
-            case "PreferOther":
-                order = ["TMDB", "TvDb", "AniDb"];
-                break;
-        }
-
-        config.DescriptionSource = "";
-        config.DescriptionSourceList = checked;
-        config.DescriptionSourceOrder = order;
-    }
 }

--- a/Shokofin/Configuration/configPage.html
+++ b/Shokofin/Configuration/configPage.html
@@ -91,7 +91,7 @@
                                     <button type="button" is="paper-icon-button-light" title="Up" class="btnSortableMoveUp btnSortable"><span class="material-icons keyboard_arrow_up" aria-hidden="true"></span></button>
                                 </div>
                             </div>
-                            <div class="fieldDescription">How to select the description to use for each item.</div>
+                            <div class="fieldDescription">The metadata providers to use as the source of episode/series/season descriptions.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
@@ -119,7 +119,7 @@
                                 <input is="emby-checkbox" type="checkbox" id="MinimalAniDBDescriptions" />
                                 <span>Minimalistic AniDB descriptions</span>
                             </label>
-                            <div class="fieldDescription checkboxFieldDescription">Trim any lines starting with '* ', '-- ',  '~ ', 'Note', 'Source', and/or 'Summery'</div>
+                            <div class="fieldDescription checkboxFieldDescription">Trim any lines starting with '* ', '-- ',  '~ ', 'Note', 'Source', and/or 'Summary'</div>
                         </div>
                         <button is="emby-button" type="submit" name="settings" class="raised button-submit block emby-button">
                             <span>Save</span>

--- a/Shokofin/Configuration/configPage.html
+++ b/Shokofin/Configuration/configPage.html
@@ -72,9 +72,6 @@
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">Add a number to the title of each specials episode</div>
                         </div>
-                        <!-- (Below) Kept to allow setting migration! -->
-                        <input is="emby-input" type="text" id="descriptionSource" style="display: none;" value="" />
-                        <!-- (Above) Kept to allow setting migration! -->
                         <div id="descriptionSourceList" style="margin-bottom: 2em;">
                             <h3 class="checkboxListLabel">Description source:</h3>
                             <div class="checkboxList paperList checkboxList-paperList">

--- a/Shokofin/Configuration/configPage.html
+++ b/Shokofin/Configuration/configPage.html
@@ -72,16 +72,26 @@
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">Add a number to the title of each specials episode</div>
                         </div>
-                        <div class="selectContainer selectContainer-withDescription">
-                            <label class="selectLabel" for="DescriptionSource">Description source:</label>
-                            <select is="emby-select" id="DescriptionSource" name="DescriptionSource" class="emby-select-withcolor emby-select">
-                                <option value="Default">Use default source for selected Series/Season grouping</option>
-                                <option value="OnlyAniDb">Only use AniDB</option>
-                                <option value="PreferAniDb">Prefer AniDB if available, otherwise use TvDB/TMDB</option>
-                                <option value="OnlyOther">Only use TvDB/TMDB</option>
-                                <option value="PreferOther">Prefer TvDB/TMDB if available, otherwise use AniDB</option>
-                            </select>
-                            <div class="fieldDescription selectFieldDescription">How to select the description to use for each item.</div>
+                        <div id="descriptionSource" style="margin-bottom: 2em;">
+                            <h3 class="checkboxListLabel">Description source:</h3>
+                            <div class="checkboxList paperList checkboxList-paperList">
+                                <div class="listItem descriptionSourceItem sortableOption" data-descriptionsource="AniDB">
+                                    <label class="listItemCheckboxContainer"><input class="chkDescriptionSource" type="checkbox" is="emby-checkbox" data-descriptionsource="AniDB"><span></span></label>
+                                    <div class="listItemBody"><h3 class="listItemBodyText">AniDB</h3></div>
+                                    <button type="button" is="paper-icon-button-light" title="Down" class="btnSortableMoveDown btnSortable"><span class="material-icons keyboard_arrow_down" aria-hidden="true"></span></button>
+                                </div>
+                                <div class="listItem descriptionSourceItem sortableOption" data-descriptionsource="TVDB">
+                                    <label class="listItemCheckboxContainer"><input class="chkDescriptionSource" type="checkbox" is="emby-checkbox" data-descriptionsource="TVDB"><span></span></label>
+                                    <div class="listItemBody"><h3 class="listItemBodyText">TVDB</h3></div>
+                                    <button type="button" is="paper-icon-button-light" title="Up" class="btnSortableMoveUp btnSortable"><span class="material-icons keyboard_arrow_up" aria-hidden="true"></span></button>
+                                </div>
+                                <div class="listItem descriptionSourceItem sortableOption" data-descriptionsource="TMDB">
+                                    <label class="listItemCheckboxContainer"><input class="chkDescriptionSource" type="checkbox" is="emby-checkbox" data-descriptionsource="TMDB"><span></span></label>
+                                    <div class="listItemBody"><h3 class="listItemBodyText">TMDB</h3></div>
+                                    <button type="button" is="paper-icon-button-light" title="Up" class="btnSortableMoveUp btnSortable"><span class="material-icons keyboard_arrow_up" aria-hidden="true"></span></button>
+                                </div>
+                            </div>
+                            <div class="fieldDescription">How to select the description to use for each item.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">

--- a/Shokofin/Configuration/configPage.html
+++ b/Shokofin/Configuration/configPage.html
@@ -75,13 +75,13 @@
                         <div id="descriptionSource" style="margin-bottom: 2em;">
                             <h3 class="checkboxListLabel">Description source:</h3>
                             <div class="checkboxList paperList checkboxList-paperList">
-                                <div class="listItem descriptionSourceItem sortableOption" data-descriptionsource="AniDB">
-                                    <label class="listItemCheckboxContainer"><input class="chkDescriptionSource" type="checkbox" is="emby-checkbox" data-descriptionsource="AniDB"><span></span></label>
+                                <div class="listItem descriptionSourceItem sortableOption" data-descriptionsource="AniDb">
+                                    <label class="listItemCheckboxContainer"><input class="chkDescriptionSource" type="checkbox" is="emby-checkbox" data-descriptionsource="AniDb"><span></span></label>
                                     <div class="listItemBody"><h3 class="listItemBodyText">AniDB</h3></div>
                                     <button type="button" is="paper-icon-button-light" title="Down" class="btnSortableMoveDown btnSortable"><span class="material-icons keyboard_arrow_down" aria-hidden="true"></span></button>
                                 </div>
-                                <div class="listItem descriptionSourceItem sortableOption" data-descriptionsource="TVDB">
-                                    <label class="listItemCheckboxContainer"><input class="chkDescriptionSource" type="checkbox" is="emby-checkbox" data-descriptionsource="TVDB"><span></span></label>
+                                <div class="listItem descriptionSourceItem sortableOption" data-descriptionsource="TvDb">
+                                    <label class="listItemCheckboxContainer"><input class="chkDescriptionSource" type="checkbox" is="emby-checkbox" data-descriptionsource="TvDb"><span></span></label>
                                     <div class="listItemBody"><h3 class="listItemBodyText">TVDB</h3></div>
                                     <button type="button" is="paper-icon-button-light" title="Up" class="btnSortableMoveUp btnSortable"><span class="material-icons keyboard_arrow_up" aria-hidden="true"></span></button>
                                 </div>

--- a/Shokofin/Configuration/configPage.html
+++ b/Shokofin/Configuration/configPage.html
@@ -72,7 +72,10 @@
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">Add a number to the title of each specials episode</div>
                         </div>
-                        <div id="descriptionSource" style="margin-bottom: 2em;">
+                        <!-- (Below) Kept to allow setting migration! -->
+                        <input is="emby-input" type="text" id="descriptionSource" style="display: none;" value="" />
+                        <!-- (Above) Kept to allow setting migration! -->
+                        <div id="descriptionSourceList" style="margin-bottom: 2em;">
                             <h3 class="checkboxListLabel">Description source:</h3>
                             <div class="checkboxList paperList checkboxList-paperList">
                                 <div class="listItem descriptionSourceItem sortableOption" data-descriptionsource="AniDb">

--- a/Shokofin/Utils/Text.cs
+++ b/Shokofin/Utils/Text.cs
@@ -167,7 +167,7 @@ public static class Text
         string overview = string.Empty;
 
         var providerOrder = Plugin.Instance.Configuration.DescriptionSourceOrder;
-        var providers = Plugin.Instance.Configuration.DescriptionSource;
+        var providers = Plugin.Instance.Configuration.DescriptionSourceList;
 
         if (providers.Length == 0) {
             return overview; // This is what they want if everything is unticked...

--- a/Shokofin/Utils/Text.cs
+++ b/Shokofin/Utils/Text.cs
@@ -221,7 +221,7 @@ public static class Text
         => GetTitles(seriesTitles, episodeTitles, null, episodeTitle, DisplayTitleType.SubTitle, metadataLanguage);
 
     public static (string?, string?) GetSeriesTitles(IEnumerable<Title> seriesTitles, string seriesTitle, string metadataLanguage)
-        => GetTitles(seriesTitles, null, seriesTitle, null,  DisplayTitleType.MainTitle, metadataLanguage);
+        => GetTitles(seriesTitles, null, seriesTitle, null, DisplayTitleType.MainTitle, metadataLanguage);
 
     public static (string?, string?) GetMovieTitles(IEnumerable<Title> seriesTitles, IEnumerable<Title> episodeTitles, string seriesTitle, string episodeTitle, string metadataLanguage)
         => GetTitles(seriesTitles, episodeTitles, seriesTitle, episodeTitle, DisplayTitleType.FullTitle, metadataLanguage);
@@ -237,7 +237,7 @@ public static class Text
         );
     }
 
-    public static string? JoinText(IEnumerable<string?> textList)
+    public static string JoinText(IEnumerable<string?> textList)
     {
         var filteredList = textList
             .Where(title => !string.IsNullOrWhiteSpace(title))
@@ -247,7 +247,7 @@ public static class Text
             .ToList();
 
         if (filteredList.Count == 0)
-            return null;
+            return string.Empty;
 
         var index = 1;
         var outputText = filteredList[0];

--- a/Shokofin/Utils/Text.cs
+++ b/Shokofin/Utils/Text.cs
@@ -142,29 +142,23 @@ public static class Text
         => GetDescription(show.DefaultSeason);
 
     public static string GetDescription(SeasonInfo season)
-    {
-        Dictionary<TextSourceType, string> descriptions = new() {
+        => GetDescription(new Dictionary<TextSourceType, string>() {
             {TextSourceType.AniDb, season.AniDB.Description ?? string.Empty},
             {TextSourceType.TvDb, season.TvDB?.Description ?? string.Empty},
-        };
-        return GetDescription(descriptions);
-    }
+        });
 
     public static string GetDescription(EpisodeInfo episode)
-    {
-        Dictionary<TextSourceType, string> descriptions = new() {
+        => GetDescription(new Dictionary<TextSourceType, string>() {
             {TextSourceType.AniDb, episode.AniDB.Description ?? string.Empty},
             {TextSourceType.TvDb, episode.TvDB?.Description ?? string.Empty},
-        };
-        return GetDescription(descriptions);
-    }
+        });
 
     public static string GetDescription(IEnumerable<EpisodeInfo> episodeList)
-        => JoinText(episodeList.Select(episode => GetDescription(episode)));
+        => JoinText(episodeList.Select(episode => GetDescription(episode))) ?? string.Empty;
 
     private static string GetDescription(Dictionary<TextSourceType, string> descriptions)
     {
-        string overview = string.Empty;
+        var overview = string.Empty;
 
         var providerOrder = Plugin.Instance.Configuration.DescriptionSourceOrder;
         var providers = Plugin.Instance.Configuration.DescriptionSourceList;
@@ -237,7 +231,7 @@ public static class Text
         );
     }
 
-    public static string JoinText(IEnumerable<string?> textList)
+    public static string? JoinText(IEnumerable<string?> textList)
     {
         var filteredList = textList
             .Where(title => !string.IsNullOrWhiteSpace(title))
@@ -247,7 +241,7 @@ public static class Text
             .ToList();
 
         if (filteredList.Count == 0)
-            return string.Empty;
+            return null;
 
         var index = 1;
         var outputText = filteredList[0];


### PR DESCRIPTION
Hopefully this should be a somewhat passable implementation of converting the description source option to being driven by orderable checkboxes (at least, in the opening state of the PR, just for further development purposes).

The changes to the plugin settings include one new setting, and one re-purposed setting.
- `DescriptionSourceOrder` has been added as an array and allows the user selected order for the description sources to persist.
- `DescriptionSource` has been repurposed into an array, containing any of the checked options

At a minimum, with these (client side only) changes implemented, the plugin settings render as expected, and there should hopefully be no further need for any significant new client side changes (for the sortable checkboxes at least).

By no means is this even slightly near ready to be merged, but all things must start somewhere (not helped by my own lack of ability).