### PR TITLE
Fix: Sets url used in manifest-unstable.json correctly

### DIFF
--- a/build_plugin.py
+++ b/build_plugin.py
@@ -35,7 +35,9 @@ with open(build_file, 'w') as file:
 
 zipfile=os.popen('jprm --verbosity=debug plugin build "." --output="%s" --version="%s" --dotnet-framework="net6.0"' % (artifact_dir, version)).read().strip()
 
-os.system('jprm repo add --url=%s %s %s' % (jellyfin_repo_url, jellyfin_repo_file, zipfile))
+jellyfin_plugin_release_url=f'{jellyfin_repo_url}/{version}/shoko_{version}.zip'
+
+os.system('jprm repo add --plugin-url=%s %s %s' % (jellyfin_plugin_release_url, jellyfin_repo_file, zipfile))
 
 # Compact the unstable manifest after building, so it only contains the last 5 versions.
 if prerelease:

--- a/manifest-unstable.json
+++ b/manifest-unstable.json
@@ -12,7 +12,7 @@
                 "version": "3.0.1.58",
                 "changelog": "refactor: overdose on `.ConfigureAwait(false)`\n\n- Use `.ConfigureAwait(false)` where-ever we can. It sped up\n  the discovery phase by 30 seconds over multiple runs, so I\n  think it should be okay to commit this now.\n\nmisc: better tracking of subtitle files\n\n- Add better tracking of the link generation for subtitle files.\n\nmisc: change default cache expire\n\n- change the cache expire time from 1h30m to 2h30m to\n  better accomodate a typical initial scan based on my testing.\n\nfix: fix vfs link creation\n\n- fix the faulty behaviour of alternatingly skipping and creating\n  symlinks because of an accidental early return.\n\nmisc: add changelog to manifest releases\n\n[skip ci]\n\nmisc: add changelog to GH pre-releases\n\n[skip ci]",
                 "targetAbi": "10.8.0.0",
-                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/shoko/shoko_3.0.1.58.zip",
+                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/3.0.1.58/shoko_3.0.1.58.zip",
                 "checksum": "1c32f315eac5dd815346c49776c07c24",
                 "timestamp": "2024-03-29T11:19:48Z"
             },
@@ -20,7 +20,7 @@
                 "version": "3.0.1.57",
                 "changelog": "NA\n",
                 "targetAbi": "10.8.0.0",
-                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/shoko/shoko_3.0.1.57.zip",
+                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/3.0.1.57/shoko_3.0.1.57.zip",
                 "checksum": "24034540bd83bbd1aa80694bbafcb2c4",
                 "timestamp": "2024-03-29T05:38:13Z"
             },
@@ -28,7 +28,7 @@
                 "version": "3.0.1.56",
                 "changelog": "NA\n",
                 "targetAbi": "10.8.0.0",
-                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/shoko/shoko_3.0.1.56.zip",
+                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/3.0.1.56/shoko_3.0.1.56.zip",
                 "checksum": "3b1322198a5614672a565cdafaaa92b4",
                 "timestamp": "2024-03-29T05:31:41Z"
             },
@@ -36,7 +36,7 @@
                 "version": "3.0.1.55",
                 "changelog": "NA\n",
                 "targetAbi": "10.8.0.0",
-                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/shoko/shoko_3.0.1.55.zip",
+                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/3.0.1.55/shoko_3.0.1.55.zip",
                 "checksum": "82036927eba09ef9b1cd153ff4903bd3",
                 "timestamp": "2024-03-29T05:18:42Z"
             },
@@ -44,7 +44,7 @@
                 "version": "3.0.1.54",
                 "changelog": "NA\n",
                 "targetAbi": "10.8.0.0",
-                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/shoko/shoko_3.0.1.54.zip",
+                "sourceUrl": "https://github.com/ShokoAnime/Shokofin/releases/download/3.0.1.54/shoko_3.0.1.54.zip",
                 "checksum": "c67234ab9f6fe1d6598d1cc30d9901ee",
                 "timestamp": "2024-03-29T05:12:38Z"
             }


### PR DESCRIPTION
It looks like [this removed line](https://github.com/ShokoAnime/Shokofin/commit/6611a79d4bfce5ce898fed2a1642deec869b85fe#diff-83008278cb77a65bde5a22415d8564eb44509e8a2d814fd2c2946e320d55903aL33) was an 'oopsie' as the URL used in `manifest-unstable.json` since then has been 404'ing.

Rather than reverting this change and continuing to invoke `sed`... It looks like `jprm` lets you override the URL which is used to update the manifest file, as demonstrated in this PR.


I've tested that the changes actually work in my own repo with GH actions ([As logged here](https://github.com/fearnlj01/Shokofin/actions/runs/8481510863/job/23238991433)), so this shouldn't break anything at least.