### PR TITLE
Prevent error being logged in the console on plugin settings page

### DIFF
--- a/Shokofin/Configuration/configPage.html
+++ b/Shokofin/Configuration/configPage.html
@@ -303,7 +303,7 @@
                             <h3>SignalR Connection</h3>
                         </legend>
                         <div class="inputContainer inputContainer-withDescription">
-                            <label class="inputLabel inputLabelUnfocused" for="SignalRStatus">Status:</label><input type="text" id="SignalRStatus" disabled readonly class="emby-input" value="Inactive">
+                            <input is="emby-input" type="text" id="SignalRStatus" label="Status:" disabled readonly value="Inactive">
                             <div class="fieldDescription">SignalR connection status.</div>
                         </div>
                         <div id="SignalRConnectContainer" hidden>

--- a/Shokofin/Configuration/configPage.html
+++ b/Shokofin/Configuration/configPage.html
@@ -303,7 +303,7 @@
                             <h3>SignalR Connection</h3>
                         </legend>
                         <div class="inputContainer inputContainer-withDescription">
-                            <label class="inputLabel inputLabelUnfocused" for="SignalRStatus">Status:</label><input is="emby-input" type="text" id="SignalRStatus" label="Status:" disabled readonly class="emby-input" value="Inactive">
+                            <label class="inputLabel inputLabelUnfocused" for="SignalRStatus">Status:</label><input type="text" id="SignalRStatus" disabled readonly class="emby-input" value="Inactive">
                             <div class="fieldDescription">SignalR connection status.</div>
                         </div>
                         <div id="SignalRConnectContainer" hidden>


### PR DESCRIPTION
Without this, errors re: this.labelElement not being defined will pop up! No idea why Jellyfin doesn't play nice...

To the best of my knowledge, I don't think this change should cause any issues, and it works as expected when loading the settings page.