### PR TITLE
Change ProviderId functions and potentially fix the series splitting because of it

### DIFF
--- a/Shokofin.sln
+++ b/Shokofin.sln
@@ -1,6 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shokofin", "Shokofin\Shokofin.csproj", "{1DD876AE-9E68-4867-BDF6-B9050E63E936}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35013.160
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shokofin", "Shokofin\Shokofin.csproj", "{1DD876AE-9E68-4867-BDF6-B9050E63E936}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -12,5 +15,11 @@ Global
 		{1DD876AE-9E68-4867-BDF6-B9050E63E936}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1DD876AE-9E68-4867-BDF6-B9050E63E936}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DD876AE-9E68-4867-BDF6-B9050E63E936}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {61FD2206-EAAB-47E0-BB8D-1033C70B3973}
 	EndGlobalSection
 EndGlobal

--- a/Shokofin/Collections/CollectionManager.cs
+++ b/Shokofin/Collections/CollectionManager.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 using Shokofin.API;
 using Shokofin.API.Info;
@@ -666,7 +667,7 @@ public class CollectionManager
             Recursive = true,
         })
             .Cast<BoxSet>()
-            .Select(x => x.ProviderIds.TryGetValue(ShokoCollectionSeriesId.Name, out var seriesId) && !string.IsNullOrEmpty(seriesId) ? new { SeriesId = seriesId, BoxSet = x } : null)
+            .Select(x => x.TryGetProviderId(ShokoCollectionSeriesId.Name, out var seriesId) ? new { SeriesId = seriesId, BoxSet = x } : null)
             .Where(x => x != null)
             .GroupBy(x => x!.SeriesId, x => x!.BoxSet)
             .ToDictionary(x => x.Key, x => x.ToList() as IReadOnlyList<BoxSet>);
@@ -683,7 +684,7 @@ public class CollectionManager
             Recursive = true,
         })
             .Cast<BoxSet>()
-            .Select(x => x.ProviderIds.TryGetValue(ShokoCollectionGroupId.Name, out var groupId) && !string.IsNullOrEmpty(groupId) ? new { GroupId = groupId, BoxSet = x } : null)
+            .Select(x => x.TryGetProviderId(ShokoCollectionGroupId.Name, out var groupId) ? new { GroupId = groupId, BoxSet = x } : null)
             .Where(x => x != null)
             .GroupBy(x => x!.GroupId, x => x!.BoxSet)
             .ToDictionary(x => x.Key, x => x.ToList() as IReadOnlyList<BoxSet>);

--- a/Shokofin/IdLookup.cs
+++ b/Shokofin/IdLookup.cs
@@ -5,6 +5,8 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+
 using Shokofin.API;
 using Shokofin.ExternalIds;
 using Shokofin.Providers;
@@ -167,7 +169,8 @@ public class IdLookup : IIdLookup
 
     public bool TryGetSeriesIdFor(Series series, [NotNullWhen(true)] out string? seriesId)
     {
-        if (series.ProviderIds.TryGetValue(ShokoSeriesId.Name, out seriesId!) && !string.IsNullOrEmpty(seriesId))
+        if (series.TryGetProviderId(ShokoSeriesId.Name, out seriesId) 
+            && series.TryGetProviderId(MetadataProvider.Custom, out _))
             return true;
 
         if (TryGetSeriesIdFor(series.Path, out seriesId)) {
@@ -185,7 +188,7 @@ public class IdLookup : IIdLookup
 
     public bool TryGetSeriesIdFor(Season season, [NotNullWhen(true)] out string? seriesId)
     {
-        if (season.ProviderIds.TryGetValue(ShokoSeriesId.Name, out seriesId) && !string.IsNullOrEmpty(seriesId))
+        if (season.TryGetProviderId(ShokoSeriesId.Name, out seriesId))
             return true;
 
         return TryGetSeriesIdFor(season.Path, out seriesId);
@@ -193,7 +196,7 @@ public class IdLookup : IIdLookup
 
     public bool TryGetSeriesIdFor(Movie movie, [NotNullWhen(true)] out string? seriesId)
     {
-        if (movie.ProviderIds.TryGetValue(ShokoSeriesId.Name, out seriesId!) && !string.IsNullOrEmpty(seriesId))
+        if (movie.TryGetProviderId(ShokoSeriesId.Name, out seriesId!))
             return true;
 
         if (TryGetEpisodeIdFor(movie.Path, out var episodeId) && TryGetSeriesIdFromEpisodeId(episodeId, out seriesId))
@@ -229,7 +232,7 @@ public class IdLookup : IIdLookup
     public bool TryGetEpisodeIdFor(BaseItem item, [NotNullWhen(true)] out string? episodeId)
     {
         // This will account for virtual episodes and existing episodes
-        if (item.ProviderIds.TryGetValue(ShokoEpisodeId.Name, out episodeId!) && !string.IsNullOrEmpty(episodeId)) {
+        if (item.TryGetProviderId(ShokoEpisodeId.Name, out episodeId!)) {
             return true;
         }
 
@@ -253,7 +256,7 @@ public class IdLookup : IIdLookup
     public bool TryGetEpisodeIdsFor(BaseItem item, [NotNullWhen(true)] out List<string>? episodeIds)
     {
         // This will account for virtual episodes and existing episodes
-        if (item.ProviderIds.TryGetValue(ShokoFileId.Name, out var fileId) && item.ProviderIds.TryGetValue(ShokoSeriesId.Name, out var seriesId) && ApiManager.TryGetEpisodeIdsForFileId(fileId, seriesId, out episodeIds!))
+        if (item.TryGetProviderId(ShokoFileId.Name, out var fileId) && item.TryGetProviderId(ShokoSeriesId.Name, out var seriesId) && ApiManager.TryGetEpisodeIdsForFileId(fileId, seriesId, out episodeIds!))
             return true;
 
         // This will account for new episodes that haven't received their first metadata update yet.
@@ -280,7 +283,7 @@ public class IdLookup : IIdLookup
 
     public bool TryGetFileIdFor(BaseItem episode, [NotNullWhen(true)] out string? fileId)
     {
-        if (episode.ProviderIds.TryGetValue(ShokoFileId.Name, out fileId!))
+        if (episode.TryGetProviderId(ShokoFileId.Name, out fileId!))
             return true;
 
         if (ApiManager.TryGetFileIdForPath(episode.Path, out fileId!))

--- a/Shokofin/MergeVersions/MergeVersionManager.cs
+++ b/Shokofin/MergeVersions/MergeVersionManager.cs
@@ -155,7 +155,7 @@ public class MergeVersionsManager
         // Merge all movies with more than one version.
         var movies = GetMoviesFromLibrary();
         var duplicationGroups = movies
-            .GroupBy(x => (x.GetTopParent()?.Path, x.ProviderIds[ShokoEpisodeId.Name]))
+            .GroupBy(x => (x.GetTopParent()?.Path, x.GetProviderId(ShokoEpisodeId.Name)))
             .Where(x => x.Count() > 1)
             .ToList();
         double currentCount = 0d;
@@ -224,7 +224,7 @@ public class MergeVersionsManager
 
         // Merge all movies with more than one version (again).
         var duplicationGroups = movies
-            .GroupBy(movie => (movie.GetTopParent()?.Path, movie.ProviderIds[ShokoEpisodeId.Name]))
+            .GroupBy(movie => (movie.GetTopParent()?.Path, movie.GetProviderId(ShokoEpisodeId.Name)))
             .Where(movie => movie.Count() > 1)
             .ToList();
         currentCount = 0d;
@@ -290,7 +290,7 @@ public class MergeVersionsManager
         // of additional episodes.
         var episodes = GetEpisodesFromLibrary();
         var duplicationGroups = episodes
-            .GroupBy(e => (e.GetTopParent()?.Path, $"{e.ProviderIds[ShokoEpisodeId.Name]}-{(e.IndexNumberEnd ?? e.IndexNumber ?? 1) - (e.IndexNumber ?? 1)}"))
+            .GroupBy(e => (e.GetTopParent()?.Path, $"{e.GetProviderId(ShokoEpisodeId.Name)}-{(e.IndexNumberEnd ?? e.IndexNumber ?? 1) - (e.IndexNumber ?? 1)}"))
             .Where(e => e.Count() > 1)
             .ToList();
         double currentCount = 0d;
@@ -361,7 +361,7 @@ public class MergeVersionsManager
         // Merge episodes with more than one version (again), and with the same
         // number of additional episodes.
         var duplicationGroups = episodes
-            .GroupBy(e => (e.GetTopParent()?.Path, $"{e.ProviderIds[ShokoEpisodeId.Name]}-{(e.IndexNumberEnd ?? e.IndexNumber ?? 1) - (e.IndexNumber ?? 1)}"))
+            .GroupBy(e => (e.GetTopParent()?.Path, $"{e.GetProviderId(ShokoEpisodeId.Name)}-{(e.IndexNumberEnd ?? e.IndexNumber ?? 1) - (e.IndexNumber ?? 1)}"))
             .Where(e => e.Count() > 1)
             .ToList();
         currentCount = 0d;

--- a/Shokofin/Providers/BoxSetProvider.cs
+++ b/Shokofin/Providers/BoxSetProvider.cs
@@ -38,12 +38,12 @@ public class BoxSetProvider : IRemoteMetadataProvider<BoxSet, BoxSetInfo>, IHasO
     {
         try {
             // Try to read the shoko group id
-            if (info.ProviderIds.TryGetValue(ShokoCollectionGroupId.Name, out var collectionId) || info.Path.TryGetAttributeValue(ShokoCollectionGroupId.Name, out collectionId))
+            if (info.TryGetProviderId(ShokoCollectionGroupId.Name, out var collectionId) || info.Path.TryGetAttributeValue(ShokoCollectionGroupId.Name, out collectionId))
                 using (Plugin.Instance.Tracker.Enter($"Providing info for Collection \"{info.Name}\". (Path=\"{info.Path}\",Collection=\"{collectionId}\")"))
                     return await GetShokoGroupMetadata(info, collectionId);
 
             // Try to read the shoko series id
-            if (info.ProviderIds.TryGetValue(ShokoCollectionSeriesId.Name, out var seriesId) || info.Path.TryGetAttributeValue(ShokoCollectionSeriesId.Name, out seriesId))
+            if (info.TryGetProviderId(ShokoCollectionSeriesId.Name, out var seriesId) || info.Path.TryGetAttributeValue(ShokoCollectionSeriesId.Name, out seriesId))
                 using (Plugin.Instance.Tracker.Enter($"Providing info for Collection \"{info.Name}\". (Path=\"{info.Path}\",Series=\"{seriesId}\")"))
                     return await GetShokoSeriesMetadata(info, seriesId);
 

--- a/Shokofin/Providers/CustomBoxSetProvider.cs
+++ b/Shokofin/Providers/CustomBoxSetProvider.cs
@@ -54,13 +54,13 @@ public class CustomBoxSetProvider : ICustomMetadataProvider<BoxSet>
             return ItemUpdateType.None;
 
         // Try to read the shoko group id
-        if (collection.ProviderIds.TryGetValue(ShokoCollectionGroupId.Name, out var collectionId) || collection.Path.TryGetAttributeValue(ShokoCollectionGroupId.Name, out collectionId))
+        if (collection.TryGetProviderId(ShokoCollectionGroupId.Name, out var collectionId) || collection.Path.TryGetAttributeValue(ShokoCollectionGroupId.Name, out collectionId))
             using (Plugin.Instance.Tracker.Enter($"Providing custom info for Collection \"{collection.Name}\". (Path=\"{collection.Path}\",Collection=\"{collectionId}\")"))
                 if (await EnsureGroupCollectionIsCorrect(collectionRoot, collection, collectionId, cancellationToken))
                     return ItemUpdateType.MetadataEdit;
 
         // Try to read the shoko series id
-        if (collection.ProviderIds.TryGetValue(ShokoCollectionSeriesId.Name, out var seriesId) || collection.Path.TryGetAttributeValue(ShokoCollectionSeriesId.Name, out seriesId))
+        if (collection.TryGetProviderId(ShokoCollectionSeriesId.Name, out var seriesId) || collection.Path.TryGetAttributeValue(ShokoCollectionSeriesId.Name, out seriesId))
             using (Plugin.Instance.Tracker.Enter($"Providing custom info for Collection \"{collection.Name}\". (Path=\"{collection.Path}\",Series=\"{seriesId}\")"))
                 if (await EnsureSeriesCollectionIsCorrect(collection, seriesId, cancellationToken))
                     return ItemUpdateType.MetadataEdit;
@@ -120,8 +120,8 @@ public class CustomBoxSetProvider : ICustomMetadataProvider<BoxSet>
 
     private bool EnsureNoTmdbIdIsSet(BoxSet collection)
     {
-        var willRemove = collection.ProviderIds.ContainsKey(MetadataProvider.TmdbCollection.ToString());
-        collection.ProviderIds.Remove(MetadataProvider.TmdbCollection.ToString());
+        var willRemove = collection.HasProviderId(MetadataProvider.TmdbCollection);
+        collection.SetProviderId(MetadataProvider.TmdbCollection.ToString(), null);
         return willRemove;
     }
 

--- a/Shokofin/Providers/CustomEpisodeProvider.cs
+++ b/Shokofin/Providers/CustomEpisodeProvider.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 using Shokofin.ExternalIds;
 
@@ -43,7 +44,7 @@ public class CustomEpisodeProvider : ICustomMetadataProvider<Episode>
             return Task.FromResult(ItemUpdateType.None);
 
         // Abort if we're unable to get the shoko episode id
-        if (episode.ProviderIds.TryGetValue(ShokoEpisodeId.Name, out var episodeId))
+        if (episode.TryGetProviderId(ShokoEpisodeId.Name, out var episodeId))
             using (Plugin.Instance.Tracker.Enter($"Providing custom info for Episode \"{episode.Name}\". (Path=\"{episode.Path}\",IsMissingEpisode={episode.IsMissingEpisode})"))
                 if (RemoveDuplicates(LibraryManager, Logger, episodeId, episode, series.GetPresentationUniqueKey()))
                     return Task.FromResult(ItemUpdateType.MetadataEdit);

--- a/Shokofin/Providers/CustomSeasonProvider.cs
+++ b/Shokofin/Providers/CustomSeasonProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 using Shokofin.API;
 using Shokofin.ExternalIds;
@@ -53,7 +54,7 @@ public class CustomSeasonProvider : ICustomMetadataProvider<Season>
 
         // Silently abort if we're unable to get the shoko series id.
         var series = season.Series;
-        if (!series.ProviderIds.TryGetValue(ShokoSeriesId.Name, out var seriesId))
+        if (!series.TryGetProviderId(ShokoSeriesId.Name, out var seriesId))
             return ItemUpdateType.None;
 
         var seasonNumber = season.IndexNumber!.Value;

--- a/Shokofin/Providers/CustomSeriesProvider.cs
+++ b/Shokofin/Providers/CustomSeriesProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 using Shokofin.API;
 using Shokofin.ExternalIds;
@@ -40,7 +41,7 @@ public class CustomSeriesProvider : ICustomMetadataProvider<Series>
     public async Task<ItemUpdateType> FetchAsync(Series series, MetadataRefreshOptions options, CancellationToken cancellationToken)
     {
         // Abort if we're unable to get the shoko series id
-        if (!series.ProviderIds.TryGetValue(ShokoSeriesId.Name, out var seriesId))
+        if (!series.TryGetProviderId(ShokoSeriesId.Name, out var seriesId))
             return ItemUpdateType.None;
 
         var trackerId = Plugin.Instance.Tracker.Add($"Providing custom info for Series \"{series.Name}\". (Series=\"{seriesId}\")");

--- a/Shokofin/Providers/EpisodeProvider.cs
+++ b/Shokofin/Providers/EpisodeProvider.cs
@@ -52,7 +52,7 @@ public class EpisodeProvider: IRemoteMetadataProvider<Episode, EpisodeInfo>, IHa
             Info.ShowInfo? showInfo = null;
             if (info.IsMissingEpisode || string.IsNullOrEmpty(info.Path)) {
                 // We're unable to fetch the latest metadata for the virtual episode.
-                if (!info.ProviderIds.TryGetValue(ShokoEpisodeId.Name, out var episodeId))
+                if (!info.TryGetProviderId(ShokoEpisodeId.Name, out var episodeId))
                     return result;
 
                 episodeInfo = await ApiManager.GetEpisodeInfo(episodeId);

--- a/Shokofin/Providers/ImageProvider.cs
+++ b/Shokofin/Providers/ImageProvider.cs
@@ -116,8 +116,8 @@ public class ImageProvider : IRemoteImageProvider, IHasOrder
                 }
                 case BoxSet collection: {
                     string? groupId = null;
-                    if (!collection.ProviderIds.TryGetValue(ShokoCollectionSeriesId.Name, out var seriesId) &&
-                        collection.ProviderIds.TryGetValue(ShokoCollectionGroupId.Name, out groupId))
+                    if (!collection.TryGetProviderId(ShokoCollectionSeriesId.Name, out var seriesId) &&
+                        collection.TryGetProviderId(ShokoCollectionGroupId.Name, out groupId))
                             seriesId = (await ApiManager.GetCollectionInfoForGroup(groupId))?.Shoko.IDs.MainSeries.ToString();
                     if (!string.IsNullOrEmpty(seriesId)) {
                         var seriesImages = await ApiClient.GetSeriesImages(seriesId);

--- a/Shokofin/Providers/SeasonProvider.cs
+++ b/Shokofin/Providers/SeasonProvider.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using Shokofin.API;
@@ -154,9 +155,10 @@ public class SeasonProvider : IRemoteMetadataProvider<Season, SeasonInfo>, IHasO
                 CommunityRating = seasonInfo.AniDB.Rating?.ToFloat(10),
             };
         }
-        season.ProviderIds.Add(ShokoSeriesId.Name, seasonInfo.Id);
+        season.SetProviderId(ShokoSeriesId.Name, seasonInfo.Id);
+
         if (Plugin.Instance.Configuration.AddAniDBId)
-            season.ProviderIds.Add("AniDB", seasonInfo.AniDB.Id.ToString());
+            season.SetProviderId("AniDB", seasonInfo.AniDB.Id.ToString());
 
         return season;
     }

--- a/Shokofin/Resolvers/ShokoLibraryMonitor.cs
+++ b/Shokofin/Resolvers/ShokoLibraryMonitor.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Emby.Naming.Common;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Shokofin.API;
@@ -289,7 +290,7 @@ public class ShokoLibraryMonitor : IHostedService
                             Logger.LogTrace("Skipped path because it is not a shoko managed file; {Path}", path);
                             return null;
                         }
-                        if (!video.ProviderIds.TryGetValue(ShokoFileId.Name, out fileId)) {
+                        if (!video.TryGetProviderId(ShokoFileId.Name, out fileId)) {
                             Logger.LogTrace("Skipped path because it is not a shoko managed file; {Path}", path);
                             return null;
                         }

--- a/Shokofin/Shokofin.csproj
+++ b/Shokofin/Shokofin.csproj
@@ -2,13 +2,13 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <OutputType>Library</OutputType>
-        <SignalRVersion>8.0.3</SignalRVersion>
+        <SignalRVersion>8.0.7</SignalRVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
-        <PackageReference Include="Jellyfin.Controller" Version="10.9.0" />
+        <PackageReference Include="Jellyfin.Controller" Version="10.9.7" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="$(SignalRVersion)" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Fixes #62 
(hopefully)

So I'll run this for a little bit on my server and if it sticks, I'll comment here. Not sure what about this fixes it but probably the extra check in `IdLookup.cs`.

I also bumped the dependencies.

EDIT: Alright this does not fix it, the series are merged but now all the Series entities have no seasons. And Episode data is still messed up after a scan, that is probably why they are no showing up. Season names also change from "Season 1" to the actual Shoko show name on the second scan. It also sets the SeriesId and Shoko Provider id of the first show in a group to all shows in said group.