### PR TITLE
VFS: recursive subfolder scanning for external files

### DIFF
--- a/Shokofin/Resolvers/VirtualFileSystemService.cs
+++ b/Shokofin/Resolvers/VirtualFileSystemService.cs
@@ -1320,9 +1320,7 @@ public class VirtualFileSystemService {
         foreach (var externalSource in externalFiles) {
             var externalDirectory = Path.GetDirectoryName(externalSource)!;
             var subdirectorySegments = Path.GetRelativePath(sourceDirectory, externalDirectory)
-                .Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries)
-                .Where(s => s is not ".")
-                .ToArray();
+                .Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
             var extName = subdirectorySegments.Length > 0
                 ? $".[{string.Join("].[", subdirectorySegments)}]"
                 : string.Empty;

--- a/Shokofin/Resolvers/VirtualFileSystemService.cs
+++ b/Shokofin/Resolvers/VirtualFileSystemService.cs
@@ -1839,19 +1839,17 @@ public class VirtualFileSystemService {
         var bufferBlock = new BufferBlock<T>(new() { BoundedCapacity = DataflowBlockOptions.Unbounded });
         var actionBlock = new ActionBlock<T>(
             inputValue => {
-                var output = action(inputValue) ?? [];
-                var outputList = output.ToList();
-                var addedCount = outputList.Count;
-
-                if (addedCount > 0) {
-                    Interlocked.Add(ref pendingCount, addedCount);
-                    foreach (var outputAction in outputList) {
+                try {
+                    var output = action(inputValue) ?? [];
+                    foreach (var outputAction in output) {
+                        Interlocked.Increment(ref pendingCount);
                         bufferBlock.Post(outputAction);
                     }
                 }
-
-                if (Interlocked.Decrement(ref pendingCount) == 0) {
-                    bufferBlock.Complete();
+                finally {
+                    if (Interlocked.Decrement(ref pendingCount) == 0) {
+                        bufferBlock.Complete();
+                    }
                 }
             },
             new() {

--- a/Shokofin/Resolvers/VirtualFileSystemService.cs
+++ b/Shokofin/Resolvers/VirtualFileSystemService.cs
@@ -1830,17 +1830,19 @@ public class VirtualFileSystemService {
         var bufferBlock = new BufferBlock<T>(new() { BoundedCapacity = DataflowBlockOptions.Unbounded });
         var actionBlock = new ActionBlock<T>(
             inputValue => {
-                try {
-                    var output = action(inputValue) ?? [];
-                    foreach (var outputAction in output) {
-                        Interlocked.Increment(ref pendingCount);
+                var output = action(inputValue) ?? [];
+                var outputList = output.ToList();
+                var addedCount = outputList.Count;
+
+                if (addedCount > 0) {
+                    Interlocked.Add(ref pendingCount, addedCount);
+                    foreach (var outputAction in outputList) {
                         bufferBlock.Post(outputAction);
                     }
                 }
-                finally {
-                    if (Interlocked.Decrement(ref pendingCount) == 0) {
-                        bufferBlock.Complete();
-                    }
+
+                if (Interlocked.Decrement(ref pendingCount) == 0) {
+                    bufferBlock.Complete();
                 }
             },
             new() {

--- a/Shokofin/Resolvers/VirtualFileSystemService.cs
+++ b/Shokofin/Resolvers/VirtualFileSystemService.cs
@@ -1134,7 +1134,7 @@ public class VirtualFileSystemService {
                 }
             }
 
-            var sourcePrefixLength = sourceLocation.Length - Path.GetExtension(sourceLocation).Length;
+            var sourcePrefixLength = Path.GetFileName(sourceLocation).Length - Path.GetExtension(sourceLocation).Length;
             var externalFiles = FindExternalFilesForPath(sourceLocation, ExternalSubtitlePathParser)
                 .Concat(FindExternalFilesForPath(sourceLocation, ExternalAudioPathParser))
                 .ToList();
@@ -1256,7 +1256,7 @@ public class VirtualFileSystemService {
                     }
                 }
 
-                LinkExternalFiles(externalFiles, symbolicLink, symbolicDirectory, sourcePrefixLength, result, preview);
+                LinkExternalFiles(sourceLocation, externalFiles, symbolicLink, symbolicDirectory, sourcePrefixLength, result, preview);
             }
 
             return result;
@@ -1273,7 +1273,7 @@ public class VirtualFileSystemService {
         if (string.IsNullOrEmpty(folderPath) || !Directory.Exists(folderPath))
             return externalPaths;
 
-        var files = GetFilePaths(folderPath)
+        var files = GetFilePaths(folderPath, recursive: true)
             .Except([sourcePath])
             .ToList();
         var sourcePrefix = Path.GetFileNameWithoutExtension(sourcePath);
@@ -1311,13 +1311,22 @@ public class VirtualFileSystemService {
         }
     }
 
-    private void LinkExternalFiles(List<string> externalFiles, string symbolicLink, string symbolicDirectory, int sourcePrefixLength, LinkGenerationResult result, bool preview) {
+    private void LinkExternalFiles(string sourceLocation, List<string> externalFiles, string symbolicLink, string symbolicDirectory, int sourcePrefixLength, LinkGenerationResult result, bool preview) {
         if (externalFiles.Count == 0)
             return;
 
         var symbolicName = Path.GetFileNameWithoutExtension(symbolicLink);
+        var sourceDirectory = Path.GetDirectoryName(sourceLocation)!;
         foreach (var externalSource in externalFiles) {
-            var extName = externalSource[sourcePrefixLength..];
+            var externalDirectory = Path.GetDirectoryName(externalSource)!;
+            var subdirectorySegments = Path.GetRelativePath(sourceDirectory, externalDirectory)
+                .Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries)
+                .Where(s => s is not ".")
+                .ToArray();
+            var extName = subdirectorySegments.Length > 0
+                ? $".[{string.Join("].[", subdirectorySegments)}]"
+                : string.Empty;
+            extName += Path.GetFileName(externalSource)[sourcePrefixLength..];
             var externalLink = Path.Join(symbolicDirectory, symbolicName + extName);
 
             result.Paths.Add(externalLink);

--- a/Shokofin/Resolvers/VirtualFileSystemService.cs
+++ b/Shokofin/Resolvers/VirtualFileSystemService.cs
@@ -1134,7 +1134,6 @@ public class VirtualFileSystemService {
                 }
             }
 
-            var sourcePrefixLength = Path.GetFileName(sourceLocation).Length - Path.GetExtension(sourceLocation).Length;
             var externalFiles = FindExternalFilesForPath(sourceLocation, ExternalSubtitlePathParser)
                 .Concat(FindExternalFilesForPath(sourceLocation, ExternalAudioPathParser))
                 .ToList();
@@ -1256,7 +1255,7 @@ public class VirtualFileSystemService {
                     }
                 }
 
-                LinkExternalFiles(sourceLocation, externalFiles, symbolicLink, symbolicDirectory, sourcePrefixLength, result, preview);
+                LinkExternalFiles(sourceLocation, externalFiles, symbolicLink, symbolicDirectory, result, preview);
             }
 
             return result;
@@ -1311,12 +1310,13 @@ public class VirtualFileSystemService {
         }
     }
 
-    private void LinkExternalFiles(string sourceLocation, List<string> externalFiles, string symbolicLink, string symbolicDirectory, int sourcePrefixLength, LinkGenerationResult result, bool preview) {
+    private void LinkExternalFiles(string sourceLocation, List<string> externalFiles, string symbolicLink, string symbolicDirectory, LinkGenerationResult result, bool preview) {
         if (externalFiles.Count == 0)
             return;
 
         var symbolicName = Path.GetFileNameWithoutExtension(symbolicLink);
         var sourceDirectory = Path.GetDirectoryName(sourceLocation)!;
+        var sourcePrefixLength = Path.GetFileName(sourceLocation).Length - Path.GetExtension(sourceLocation).Length;
         foreach (var externalSource in externalFiles) {
             var externalDirectory = Path.GetDirectoryName(externalSource)!;
             var subdirectorySegments = Path.GetRelativePath(sourceDirectory, externalDirectory)

--- a/Shokofin/Resolvers/VirtualFileSystemService.cs
+++ b/Shokofin/Resolvers/VirtualFileSystemService.cs
@@ -1134,9 +1134,6 @@ public class VirtualFileSystemService {
                 }
             }
 
-            var externalFiles = FindExternalFilesForPath(sourceLocation, ExternalSubtitlePathParser)
-                .Concat(FindExternalFilesForPath(sourceLocation, ExternalAudioPathParser))
-                .ToList();
             foreach (var symbolicLink in symbolicLinks) {
                 var symbolicDirectory = Path.GetDirectoryName(symbolicLink)!;
                 if (!Directory.Exists(symbolicDirectory))
@@ -1255,7 +1252,7 @@ public class VirtualFileSystemService {
                     }
                 }
 
-                LinkExternalFiles(sourceLocation, externalFiles, symbolicLink, symbolicDirectory, result, preview);
+                LinkExternalFiles(sourceLocation, symbolicLink, symbolicDirectory, result, preview);
             }
 
             return result;
@@ -1310,7 +1307,10 @@ public class VirtualFileSystemService {
         }
     }
 
-    private void LinkExternalFiles(string sourceLocation, List<string> externalFiles, string symbolicLink, string symbolicDirectory, LinkGenerationResult result, bool preview) {
+    private void LinkExternalFiles(string sourceLocation, string symbolicLink, string symbolicDirectory, LinkGenerationResult result, bool preview) {
+        var externalFiles = FindExternalFilesForPath(sourceLocation, ExternalSubtitlePathParser)
+            .Concat(FindExternalFilesForPath(sourceLocation, ExternalAudioPathParser))
+            .ToList();
         if (externalFiles.Count == 0)
             return;
 

--- a/Shokofin/Resolvers/VirtualFileSystemService.cs
+++ b/Shokofin/Resolvers/VirtualFileSystemService.cs
@@ -1318,13 +1318,9 @@ public class VirtualFileSystemService {
         var sourceDirectory = Path.GetDirectoryName(sourceLocation)!;
         var sourcePrefixLength = Path.GetFileName(sourceLocation).Length - Path.GetExtension(sourceLocation).Length;
         foreach (var externalSource in externalFiles) {
-            var externalDirectory = Path.GetDirectoryName(externalSource)!;
-            var subdirectorySegments = Path.GetRelativePath(sourceDirectory, externalDirectory)
-                .Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
-            var extName = subdirectorySegments.Length > 0
-                ? $".[{string.Join("].[", subdirectorySegments)}]"
-                : string.Empty;
-            extName += Path.GetFileName(externalSource)[sourcePrefixLength..];
+            var extName = Path.GetFileName(externalSource)[sourcePrefixLength..];
+            if (Path.GetRelativePath(sourceDirectory, Path.GetDirectoryName(externalSource)!) is not "." and { Length: > 0 } relativePath)
+                extName = $".[{relativePath.Split(Path.DirectorySeparatorChar).Join("].[")}]" + extName;
             var externalLink = Path.Join(symbolicDirectory, symbolicName + extName);
 
             result.Paths.Add(externalLink);


### PR DESCRIPTION
## Summary
- External subtitle and audio file discovery now searches subdirectories recursively,
  not just the immediate parent folder of the source file
- Subfolder structure is encoded in symbolic link names using `.[segment]` notation
  to preserve origin and avoid name collisions
- Fixed `sourcePrefixLength` calculation to use filename length instead of full path length
- Improved `Parallelize` concurrency pattern with batch count updates

## Example

Given a source media folder structured like:

```
Media Folder/
├── Video File.mkv
├── Subs/
│   ├── Video File.en.ass
│   └── Video File.signs.ass
└── Audio/
    ├── Dub A/
    │   └── Video File.Dub A.m4a
    └── Dub B/
        └── Video File.Dub B.mka
```

Previously, only external files in the same directory as the video were discovered.
Files in `Subs/` and `Audio/` subdirectories were ignored entirely.

With this change, the VFS generates the following symbolic links:

```
.../VFS/{library-id}/Series Name [Shoko Series=ID]/Season ID/
├── Series Name S01E01 [Shoko Series=ID] [Shoko File=ID].mkv
├── Series Name S01E01 [Shoko Series=ID] [Shoko File=ID].[Subs].en.ass
├── Series Name S01E01 [Shoko Series=ID] [Shoko File=ID].[Subs].signs.ass
├── Series Name S01E01 [Shoko Series=ID] [Shoko File=ID].[Audio].[Dub A].Dub A.m4a
└── Series Name S01E01 [Shoko Series=ID] [Shoko File=ID].[Audio].[Dub B].Dub B.mka
```

The `.[folder]` segments encode the subdirectory path in the symlink name,
ensuring files from different subfolders don't collide.
