### PR TITLE
Fix user watch state syncing logic.

### DIFF
--- a/Shokofin/Extensions/SyncExtensions.cs
+++ b/Shokofin/Extensions/SyncExtensions.cs
@@ -74,7 +74,7 @@ public static class SyncExtensions {
         userData.Played = userStats.LastWatchedAt.HasValue;
         userData.PlayCount = userStats.WatchedCount;
         userData.PlaybackPositionTicks = userStats.ResumePosition?.Ticks ?? 0;
-        userData.LastPlayedDate = userStats.ResumePosition.HasValue ? userStats.LastUpdatedAt : userStats.LastWatchedAt ?? userStats.LastUpdatedAt;
+        userData.LastPlayedDate = userStats.LastWatchedAt ?? (userStats.ResumePosition.HasValue ? userStats.LastUpdatedAt : null);
         return userData;
     }
 
@@ -84,6 +84,6 @@ public static class SyncExtensions {
             Played = userStats.LastWatchedAt.HasValue,
             PlayCount = userStats.WatchedCount,
             PlaybackPositionTicks = userStats.ResumePosition?.Ticks ?? 0,
-            LastPlayedDate = userStats.ResumePosition.HasValue ? userStats.LastUpdatedAt : userStats.LastWatchedAt ?? userStats.LastUpdatedAt,
+            LastPlayedDate = userStats.LastWatchedAt ?? (userStats.ResumePosition.HasValue ? userStats.LastUpdatedAt : null),
         };
 }


### PR DESCRIPTION
This fixes an issue that became noticable on Jellyfin 10.11 where criteria as to what appears in Next Up. Series that have been marked as watched and then completely marked as unwatched for a user whose watch state is synced to Shoko would have S01E01 of the offending series show up in Next Up upon a resync due to userData.LastPlayedDate being set to LastUpdateAt which always exists.