### PR TITLE
Jf 10.11 userdata insertion guard

### DIFF
--- a/Shokofin/Database/UserDataRepositoryService.cs
+++ b/Shokofin/Database/UserDataRepositoryService.cs
@@ -84,24 +84,44 @@ public class UserDataRepositoryService
     public void SaveUserDataForNewKey(string key, UserItemData data, User user, Guid newItemId) {
 #if NET9_0
         using var context = _dbContextFactory.CreateDbContext();
-        var entry = new UserData {
-            CustomDataKey = key,
-            ItemId = newItemId,
-            UserId = user.Id,
-            Item = null!,
-            User = null!,
-            RetentionDate = null,
-            Rating = data.Rating,
-            PlaybackPositionTicks = data.PlaybackPositionTicks,
-            PlayCount = data.PlayCount,
-            IsFavorite = data.IsFavorite,
-            LastPlayedDate = data.LastPlayedDate,
-            Played = data.Played,
-            AudioStreamIndex = data.AudioStreamIndex,
-            SubtitleStreamIndex = data.SubtitleStreamIndex,
-            Likes = data.Likes,
-        };
-        context.UserData.Add(entry);
+
+        // If a row already exists for this (ItemId, UserId, CustomDataKey) composite key,
+        // update it in place. Otherwise Jellyfin's ReattachUserDataAsync will attempt to
+        // move placeholder rows to the same key and hit a UNIQUE CONSTRAINT violation.
+        var existing = context.UserData
+            .FirstOrDefault(e => e.ItemId == newItemId && e.UserId == user.Id && e.CustomDataKey == key);
+
+        if (existing is not null) {
+            existing.Rating = data.Rating;
+            existing.PlaybackPositionTicks = data.PlaybackPositionTicks;
+            existing.PlayCount = data.PlayCount;
+            existing.IsFavorite = data.IsFavorite;
+            existing.LastPlayedDate = data.LastPlayedDate;
+            existing.Played = data.Played;
+            existing.AudioStreamIndex = data.AudioStreamIndex;
+            existing.SubtitleStreamIndex = data.SubtitleStreamIndex;
+            existing.Likes = data.Likes;
+        }
+        else {
+            var entry = new UserData {
+                CustomDataKey = key,
+                ItemId = newItemId,
+                UserId = user.Id,
+                Item = null!,
+                User = null!,
+                RetentionDate = null,
+                Rating = data.Rating,
+                PlaybackPositionTicks = data.PlaybackPositionTicks,
+                PlayCount = data.PlayCount,
+                IsFavorite = data.IsFavorite,
+                LastPlayedDate = data.LastPlayedDate,
+                Played = data.Played,
+                AudioStreamIndex = data.AudioStreamIndex,
+                SubtitleStreamIndex = data.SubtitleStreamIndex,
+                Likes = data.Likes,
+            };
+            context.UserData.Add(entry);
+        }
         context.SaveChanges();
 #else
         using var connection = new SqliteConnection($"Data Source={_dbPath}");

--- a/Shokofin/Database/UserDataRepositoryService.cs
+++ b/Shokofin/Database/UserDataRepositoryService.cs
@@ -19,6 +19,12 @@ public class UserDataRepositoryService
 #if NET9_0
     private readonly IDbContextFactory<JellyfinDbContext> _dbContextFactory;
 
+    /// <summary>
+    /// The sentinel GUID Jellyfin uses as a placeholder for detached UserData rows.
+    /// Must match BaseItemRepository.PlaceholderId.
+    /// </summary>
+    private static readonly Guid PlaceholderId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
     public UserDataRepositoryService(
         IDbContextFactory<JellyfinDbContext> dbContextFactory) {
         _dbContextFactory = dbContextFactory;
@@ -103,6 +109,16 @@ public class UserDataRepositoryService
             existing.Likes = data.Likes;
         }
         else {
+            // Delete any placeholder row that shares the same (UserId, CustomDataKey).
+            // Without this, Jellyfin's ReattachUserDataAsync will attempt to move the
+            // placeholder row to this ItemId and hit a UNIQUE CONSTRAINT violation
+            // because our row already occupies that (ItemId, UserId, CustomDataKey) slot.
+            // This mirrors what Jellyfin itself does for the tombstone path in
+            // BaseItemRepository (commit 482271c / PR #14475).
+            context.UserData
+                .Where(e => e.ItemId == PlaceholderId && e.UserId == user.Id && e.CustomDataKey == key)
+                .ExecuteDelete();
+
             var entry = new UserData {
                 CustomDataKey = key,
                 ItemId = newItemId,

--- a/Shokofin/Sync/UserDataSyncManager.cs
+++ b/Shokofin/Sync/UserDataSyncManager.cs
@@ -648,7 +648,15 @@ public class UserDataSyncManager {
                     // Abort since there are no remote stats to import.
                     if (remoteUserStats == null)
                         break;
-                    // Create a new local stats entry if there is no local entry.
+                    // Re-read local stats in case Jellyfin's ReattachUserDataAsync
+                    // populated the UserData rows while we were waiting on the
+                    // Shoko API call. If the reattachment already wrote rows for
+                    // this item, a blind SaveUserData would race it and trigger
+                    // a UNIQUE CONSTRAINT violation on (ItemId, UserId, CustomDataKey).
+                    if (localUserStats == null)
+                        localUserStats = UserDataManager.GetUserData(user, video);
+
+                    // Create a new local stats entry if there is still no local entry.
                     if (localUserStats == null) {
                         UserDataManager.SaveUserData(user, video, localUserStats = remoteUserStats.ToUserData(video), UserDataSaveReason.Import, CancellationToken.None);
                         Logger.LogDebug("{SyncDirection} user data for video {VideoName} successful. (User={UserId},File={FileId},Series={SeriesId})", SyncDirection.Import.ToString(), video.Name, userConfig.UserId, fileId, seriesId);

--- a/Shokofin/Sync/UserDataSyncManager.cs
+++ b/Shokofin/Sync/UserDataSyncManager.cs
@@ -648,15 +648,7 @@ public class UserDataSyncManager {
                     // Abort since there are no remote stats to import.
                     if (remoteUserStats == null)
                         break;
-                    // Re-read local stats in case Jellyfin's ReattachUserDataAsync
-                    // populated the UserData rows while we were waiting on the
-                    // Shoko API call. If the reattachment already wrote rows for
-                    // this item, a blind SaveUserData would race it and trigger
-                    // a UNIQUE CONSTRAINT violation on (ItemId, UserId, CustomDataKey).
-                    if (localUserStats == null)
-                        localUserStats = UserDataManager.GetUserData(user, video);
-
-                    // Create a new local stats entry if there is still no local entry.
+                    // Create a new local stats entry if there is no local entry.
                     if (localUserStats == null) {
                         UserDataManager.SaveUserData(user, video, localUserStats = remoteUserStats.ToUserData(video), UserDataSaveReason.Import, CancellationToken.None);
                         Logger.LogDebug("{SyncDirection} user data for video {VideoName} successful. (User={UserId},File={FileId},Series={SeriesId})", SyncDirection.Import.ToString(), video.Name, userConfig.UserId, fileId, seriesId);


### PR DESCRIPTION
SaveUserDataForNewKey previously did a blind insert of the migrated UserData row, which would collide with Jellyfin's ReattachUserDataAsync when it tried to move tombstoned placeholder rows to the same (ItemId, UserId, CustomDataKey) slot.

This fix now deletes any conflicting placeholder row before inserting, so the reattachment has nothing to move. It also checks whether the destination already has a row and updates in place, handling the reverse case where the reattachment wins the race.