### PR TITLE
Add setting to use Shoko titles/images for series when using Tmdb structure

### DIFF
--- a/Shokofin/API/ShokoApiManager.cs
+++ b/Shokofin/API/ShokoApiManager.cs
@@ -1757,6 +1757,17 @@ public partial class ShokoApiManager : IDisposable {
             .ToList();
     }
 
+    public async Task<ShowInfo?> GetMainShokoSeriesShowInfo(string? seasonId) {
+        if (string.IsNullOrEmpty(seasonId))
+            return null;
+
+        var group = await ApiClient.GetShokoGroupForShokoSeries(seasonId);
+        if (group == null || group.IDs.MainSeries <= 0)
+            return await GetShowInfoBySeasonId(seasonId);
+
+        return await GetShowInfoBySeasonId(group.IDs.MainSeries.ToString());
+    }
+
     public async Task<ShowInfo?> GetShowInfoBySeasonId(string seasonId) {
         if (string.IsNullOrEmpty(seasonId))
             return null;

--- a/Shokofin/API/ShokoApiManager.cs
+++ b/Shokofin/API/ShokoApiManager.cs
@@ -1757,13 +1757,13 @@ public partial class ShokoApiManager : IDisposable {
             .ToList();
     }
 
-    public async Task<ShowInfo?> GetMainShokoSeriesShowInfo(string? seasonId) {
-        if (string.IsNullOrEmpty(seasonId))
+    public async Task<ShowInfo?> GetMainShokoSeriesShowInfo(string? seriesId) {
+        if (string.IsNullOrEmpty(seriesId))
             return null;
 
-        var group = await ApiClient.GetShokoGroupForShokoSeries(seasonId);
+        var group = await ApiClient.GetShokoGroupForShokoSeries(seriesId);
         if (group == null || group.IDs.MainSeries <= 0)
-            return await GetShowInfoBySeasonId(seasonId);
+            return await GetShowInfoBySeasonId(seriesId);
 
         return await GetShowInfoBySeasonId(group.IDs.MainSeries.ToString());
     }

--- a/Shokofin/Configuration/PluginConfiguration.cs
+++ b/Shokofin/Configuration/PluginConfiguration.cs
@@ -498,6 +498,12 @@ public class PluginConfiguration : BasePluginConfiguration {
     public bool FilterMovieLibraries { get; set; }
 
     /// <summary>
+    /// Use Shoko titles and images for top level series when
+    /// using TMDB series structure.
+    /// </summary>
+    public bool TmdbStructureUseShokoMetadata { get; set; }
+
+    /// <summary>
     /// Append all specials in AniDB movie series as special features for
     /// the movies.
     /// </summary>

--- a/Shokofin/Pages/Scripts/Common.js
+++ b/Shokofin/Pages/Scripts/Common.js
@@ -545,6 +545,7 @@ export const LibraryMenu = globalThis.LibraryMenu;
  *   UseGroupsForShows: boolean;
  *   SeparateMovies: boolean;
  *   FilterMovieLibraries: boolean;
+ *   TmdbStructureUseShokoMetadata: boolean;
  *   MovieSpecialsAsExtraFeaturettes: boolean;
  *   AddTrailers: boolean;
  *   AddCreditsAsThemeVideos: boolean;

--- a/Shokofin/Pages/Scripts/Settings.js
+++ b/Shokofin/Pages/Scripts/Settings.js
@@ -630,6 +630,7 @@ function applyFormToConfig(form, config) {
             config.SeparateMovies = form.querySelector("#SeparateMovies").checked;
             config.FilterMovieLibraries = !form.querySelector("#DisableFilterMovieLibraries").checked;
             config.DefaultSpecialsPlacement = form.querySelector("#DefaultSpecialsPlacement").value;
+            config.TmdbStructureUseShokoMetadata = form.querySelector("#TmdbStructureUseShokoMetadata").checked;
             config.MovieSpecialsAsExtraFeaturettes = form.querySelector("#MovieSpecialsAsExtraFeaturettes").checked;
             config.AddMissingMetadata = form.querySelector("#AddMissingMetadata").checked;
 
@@ -916,6 +917,7 @@ async function applyConfigToForm(form, config) {
             form.querySelector("#SeparateMovies").checked = config.SeparateMovies;
             form.querySelector("#DisableFilterMovieLibraries").checked = !config.FilterMovieLibraries;
             form.querySelector("#DefaultSpecialsPlacement").value = config.DefaultSpecialsPlacement === "Default" ? "Excluded" : config.DefaultSpecialsPlacement;
+            form.querySelector("#TmdbStructureUseShokoMetadata").checked = config.TmdbStructureUseShokoMetadata;
             form.querySelector("#MovieSpecialsAsExtraFeaturettes").checked = config.MovieSpecialsAsExtraFeaturettes;
             form.querySelector("#AddMissingMetadata").checked = config.AddMissingMetadata;
 

--- a/Shokofin/Pages/Settings.html
+++ b/Shokofin/Pages/Settings.html
@@ -1694,7 +1694,7 @@ form:not(.advanced-mode) .advanced-only {
                                 <input is="emby-checkbox" type="checkbox" id="TmdbStructureUseShokoMetadata" />
                                 <span>Use Shoko Series Titles/Images with Tmdb Structure</span>
                             </label>
-                            <div class="fieldDescription checkboxFieldDescription">Using 'TheMovieDb Shows &amp; Movie Structure' normally forces Shokofin to use Tmdb as the source for all series metadata. Enable this setting to use Shoko as the source of series titles and images. This option only applies to the top level series displayed in your library. Season and episode titles/images are still sourced from Tmdb. This setting has no effect on any series not using Tmdb structure.</div>
+                            <div class="fieldDescription checkboxFieldDescription">Using 'TheMovieDb Shows &amp; Movie Structure' normally forces the plugin to use TheMovieDb as the source for all series metadata. Enable this setting to use Shoko as the source of series titles and images. This option only applies to the top level series displayed in your library. Season and episode titles/images are still sourced from TheMovieDb. This setting has no effect on any series not using TheMovieDb structure.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription advanced-only">
                             <label class="emby-checkbox-label">

--- a/Shokofin/Pages/Settings.html
+++ b/Shokofin/Pages/Settings.html
@@ -1691,6 +1691,13 @@ form:not(.advanced-mode) .advanced-only {
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription advanced-only">
                             <label class="emby-checkbox-label">
+                                <input is="emby-checkbox" type="checkbox" id="TmdbStructureUseShokoMetadata" />
+                                <span>Use Shoko Series Titles/Images with Tmdb Structure</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">Using 'TheMovieDb Shows &amp; Movie Structure' normally forces Shokofin to use Tmdb as the source for all series metadata. Enable this setting to use Shoko as the source of series titles and images. This option only applies to the top level series displayed in your library. Season and episode titles/images are still sourced from Tmdb. This setting has no effect on any series not using Tmdb structure.</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription advanced-only">
+                            <label class="emby-checkbox-label">
                                 <input is="emby-checkbox" type="checkbox" id="MovieSpecialsAsExtraFeaturettes" />
                                 <span>Force Movie Special Features</span>
                             </label>

--- a/Shokofin/Providers/ImageProvider.cs
+++ b/Shokofin/Providers/ImageProvider.cs
@@ -48,6 +48,16 @@ public class ImageProvider(IHttpClientFactory _httpClientFactory, ILogger<ImageP
                     if (!_lookup.TryGetSeasonIdFor(series, out var seasonId) || await _apiManager.GetShowInfoBySeasonId(seasonId) is not { } showInfo)
                         break;
 
+                    // If using Shoko titles/images for TMDB structure is enabled,
+                    // find the main shoko series for this show and use it to generate images.
+                    if (
+                        showInfo.DefaultSeason.StructureType == Configuration.SeriesStructureType.TMDB_SeriesAndMovies &&
+                        Plugin.Instance.Configuration.TmdbStructureUseShokoMetadata
+                    ) {
+                        var overrideShowInfo = await _apiManager.GetMainShokoSeriesShowInfo(showInfo.ShokoSeriesId);
+                        showInfo = overrideShowInfo ?? showInfo;
+                    }
+
                     var images = await ImageUtility.GetShowImages(showInfo, metadataLanguage, displayMode, cancellationToken);
                     list.AddRange(images);
 

--- a/Shokofin/Providers/ImageProvider.cs
+++ b/Shokofin/Providers/ImageProvider.cs
@@ -51,7 +51,7 @@ public class ImageProvider(IHttpClientFactory _httpClientFactory, ILogger<ImageP
                     // If using Shoko titles/images for TMDB structure is enabled,
                     // find the main shoko series for this show and use it to generate images.
                     if (
-                        showInfo.DefaultSeason.StructureType == Configuration.SeriesStructureType.TMDB_SeriesAndMovies &&
+                        showInfo.DefaultSeason.StructureType is Configuration.SeriesStructureType.TMDB_SeriesAndMovies &&
                         Plugin.Instance.Configuration.TmdbStructureUseShokoMetadata
                     ) {
                         var overrideShowInfo = await _apiManager.GetMainShokoSeriesShowInfo(showInfo.ShokoSeriesId);

--- a/Shokofin/Providers/SeriesProvider.cs
+++ b/Shokofin/Providers/SeriesProvider.cs
@@ -46,7 +46,17 @@ public class SeriesProvider(IHttpClientFactory _httpClientFactory, ILogger<Serie
                 }
             }
 
-            var (displayTitle, alternateTitle) = TextUtility.GetShowTitles(showInfo, info.MetadataLanguage);
+            // If using Shoko titles/images for TMDB structure is enabled,
+            // find the main shoko series for this show and use it to generate titles.
+            API.Info.ShowInfo? titleOverrideShowInfo = null;
+            if (
+                showInfo.DefaultSeason.StructureType == Configuration.SeriesStructureType.TMDB_SeriesAndMovies &&
+                Plugin.Instance.Configuration.TmdbStructureUseShokoMetadata
+            ) {
+                titleOverrideShowInfo = await _apiManager.GetMainShokoSeriesShowInfo(showInfo.ShokoSeriesId);
+            }
+
+            var (displayTitle, alternateTitle) = TextUtility.GetShowTitles(titleOverrideShowInfo ?? showInfo, info.MetadataLanguage);
             if (string.IsNullOrEmpty(displayTitle))
                 displayTitle = showInfo.Title;
 

--- a/Shokofin/Providers/SeriesProvider.cs
+++ b/Shokofin/Providers/SeriesProvider.cs
@@ -50,7 +50,7 @@ public class SeriesProvider(IHttpClientFactory _httpClientFactory, ILogger<Serie
             // find the main shoko series for this show and use it to generate titles.
             API.Info.ShowInfo? titleOverrideShowInfo = null;
             if (
-                showInfo.DefaultSeason.StructureType == Configuration.SeriesStructureType.TMDB_SeriesAndMovies &&
+                showInfo.DefaultSeason.StructureType is Configuration.SeriesStructureType.TMDB_SeriesAndMovies &&
                 Plugin.Instance.Configuration.TmdbStructureUseShokoMetadata
             ) {
                 titleOverrideShowInfo = await _apiManager.GetMainShokoSeriesShowInfo(showInfo.ShokoSeriesId);


### PR DESCRIPTION
When using TMDB structure, Shokofin currently forces all metadata to come from TMDB. This PR adds a setting to enable fetching series titles and images using the Shoko series corresponding to the show's main series.

This change only applies to the top-level series thats displayed in the jellyfin library. Season titles and images are not affected and still pull from TMDB. Movies are also not affected by this, but I may add movie support in a separate PR later.

The only potential concern I have with this change is the extra API load created by retrieving a Shoko Group. Not sure how expensive this is, but I'd imagine its fine. There also might be a more direct way to fetch the "main" shoko series for a specific series that I missed.

I've tested this on my entire library ~700 series and ~13000 files and it worked flawlessly, but I am relatively new to using both Shoko and Jellyfin so its possible there could be issues with certain configurations.