### PR TITLE
fix: use Shoko UID for image URLs

### DIFF
--- a/Shokofin/API/Models/Image.cs
+++ b/Shokofin/API/Models/Image.cs
@@ -7,7 +7,7 @@ public class Image {
     /// <summary>
     ///   The unique image id to use when identifying the image upstream.
     /// </summary>
-    private string UniqueImageId => OID.HasValue ? OID.Value.ToString("D") : $"{Source}/{Type}/{ID}"; 
+    private string UniqueImageId => UID.HasValue ? UID.Value.ToString("D") : $"{Source}/{Type}/{ID}";
 
     /// <summary>
     /// AniDB, TMDB, etc.
@@ -28,7 +28,7 @@ public class Image {
     /// <summary>
     /// The image's GUID, for newer versions of Shoko.
     /// </summary>
-    public Guid? OID { get; set; }
+    public Guid? UID { get; set; }
 
     /// <summary>
     /// True if the image is marked as the preferred for the given shoko image
@@ -96,7 +96,7 @@ public class Image {
         Source = image.Source;
         Type = image.Type;
         ID = image.ID;
-        OID = image.OID;
+        UID = image.UID;
         IsPreferred = image.IsPreferred;
         IsDisabled = image.IsDisabled;
         LanguageCode = image.LanguageCode;


### PR DESCRIPTION
## Summary

- Deserialize the image GUID from Shoko's `UID` field.
- Use that UID when generating hosted image URLs.
- Preserve the existing source/type/ID fallback for older Shoko versions.

## Problem

Current Shoko image responses identify images using a `UID` property. Shokofin's image model instead expects that value in a property named `OID`.

Because `System.Text.Json` does not map `UID` to `OID`, the GUID remains unset. Shokofin then falls back to the legacy source/type/ID route. On newer Shoko responses, the legacy numeric ID may be absent and defaults to `0`, producing invalid image URLs ending in `/0`.

## Compatibility

The legacy source/type/ID fallback remains unchanged, so older Shoko versions that still return usable numeric image IDs should continue to work.

This fix is independent of the Jellyfin 12 compatibility work and can be reviewed separately.
